### PR TITLE
Add weekly expiry checker & improve scraper/expiry flow

### DIFF
--- a/Refine/extractor.py
+++ b/Refine/extractor.py
@@ -4,6 +4,8 @@ from Refine.llm import  LLMProvider, OllamaProvider
 from Utils.constants import Config
 from Utils.models import Job
 from Service.Scrapper import Pirate
+from Service.db import JobDatabase
+
 
 # ─── Stage 1: Regex ────────────────────────────────────────────────────────────
 class RegexConstants:
@@ -205,7 +207,8 @@ class JobEnricher:
     This allows for stateful configuration and easier testing.
     """
 
-    def __init__(self, provider: Optional[LLMProvider] = None, use_llm: bool = True, llm_delay: float = 0.5):
+    def __init__(self,job_id: uuid.UUID, provider: Optional[LLMProvider] = None, use_llm: bool = True, llm_delay: float = 0.5):
+        self.job_id = job_id
         self.provider = provider or OllamaProvider()
         self.use_llm = use_llm
         self.llm_delay = llm_delay
@@ -254,7 +257,7 @@ class JobEnricher:
 
         if status == "expired":
             self.meta["stages_run"].append("scrape_expired")
-            self._mark_expired(job)
+            await self._mark_expired()
             return
 
         if status == "garbage":
@@ -286,7 +289,7 @@ class JobEnricher:
             extracted = self.provider.extract(job, scraped)
             if extracted.get("job_expired"):
                 self.meta["stages_run"].append("llm_expired")
-                return self._mark_expired(job)
+                return await self._mark_expired()
             filled = self._apply_to_job(job, extracted)
             self.meta["fields_filled"].extend(f"{f} (llm+scrape)" for f in filled)
         Config.logger.info(f"Finished enriching job: {job.title} at {job.company} for {job}")
@@ -323,11 +326,11 @@ class JobEnricher:
         filled = self._apply_to_job(job, extracted)
         self.meta["fields_filled"].extend( f"{field} (regex)" for field in filled)
 
-    def _mark_expired(self, job: "Job"):
+    async def _mark_expired(self):
         """Shared exit path for any stage that determines the listing is expired."""
-        job.description = "This listing is no longer available."
+        db = await JobDatabase.create()
+        await db.update( table="job_list", filters={"id": self.job_id}, data={"status": "expired", "enriched": True},)
         self.meta["expired"] = True
-        Config.logger.info(f"Finished enriching job: {job.title} at {job.company} for {job}")
         Config.logger.info(f"Done. Filled: {self.meta['fields_filled']}")
         
     async def _run_scrape(self, job: "Job"):
@@ -343,7 +346,7 @@ class JobEnricher:
             self.meta["stages_run"].append("structured_data")
             if scraped.get("job_expired"):
                 self.meta["stages_run"].append("structured_expired")
-                self._mark_expired(job)
+                await self._mark_expired()
                 return
             filled = self._apply_structured_data(job, scraped)
 
@@ -355,7 +358,7 @@ class JobEnricher:
                 extracted = self.provider.extract(job, job.description)
                 if extracted.get("job_expired"):
                     self.meta["stages_run"].append("llm_expired")
-                    return self._mark_expired(job)
+                    return await  self._mark_expired()
                 filled = self._apply_to_job(job, extracted)
                 self.meta["fields_filled"].extend(f"{f} (llm+structured)" for f in filled)
                 Config.logger.info(f"Finished enriching job: {job.title} at {job.company} for {job}")
@@ -408,7 +411,7 @@ class JobEnricher:
 if __name__ == "__main__":
     
     company_id = uuid.UUID("6c8333ed-7275-4565-9392-81a9aa46aa45")
-
+    job_id = uuid.uuid4()
     job1 = Job(
         title="Associate Web Developer (.Net)",
         company=company_id,
@@ -427,7 +430,7 @@ if __name__ == "__main__":
 
 
     # Swap provider here —  or GeminiProvider()
-    extractor = JobEnricher(provider=OllamaProvider(), use_llm=True, llm_delay=0.5)
+    extractor = JobEnricher(job_id=job_id, provider=OllamaProvider(), use_llm=True, llm_delay=0.5)
     meta = asyncio.run(extractor.enrich_job(job1))
 
     print("\n=== After ===")

--- a/Refine/llm.py
+++ b/Refine/llm.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
-import json,re
+from typing import Optional
+import json, re
 #for when we later want to add a local model option:
 #import os,torch
 #from transformers import AutoModelForCausalLM, AutoTokenizer, pipeline
@@ -128,6 +129,63 @@ class LLMProvider(ABC):
                 f"response. Raw (truncated): {cleaned[:300]!r}"
             )
             raise LLMParseError(f"Could not parse LLM response as JSON: {e}") from e
+
+    def _build_expired_check_prompt(self, text: str) -> str:
+        # Expiry wording is almost always near the top of a posting or in a
+        # banner/interstitial, not buried at the bottom — truncate hard to
+        # keep this prompt (and the model's read of it) cheap.
+        snippet = text[:3000]
+        return (
+            "You are checking whether a scraped job-posting web page indicates "
+            "that the listing is closed, expired, filled, or no longer available.\n\n"
+            'Respond with ONLY a JSON object of the exact shape {"expired": true} '
+            'or {"expired": false} — no other text, no markdown, no explanation.\n\n'
+            'If the page clearly shows an active, open job posting, respond '
+            '{"expired": false}. If it shows any indication the posting is '
+            'closed, filled, expired, or no longer accepting applications, '
+            'respond {"expired": true}. If the text is unclear or you are '
+            'genuinely unsure, respond {"expired": false} — do not guess '
+            "expired without a clear signal.\n\n"
+            f"Page text:\n{snippet}"
+        )
+
+    def check_expired(self, text: str) -> Optional[bool]:
+        """
+        Narrow, single-purpose check: does this scraped page text indicate
+        the job listing is no longer available? Unlike extract(), this needs
+        no Job object — just the scraped text — and asks for a single boolean
+        rather than the full multi-field extraction shape.
+
+        Returns True/False, or None if the call failed or the response
+        couldn't be parsed as a clear verdict (caller should treat None as
+        inconclusive, not as "not expired").
+        """
+        prompt = self._build_expired_check_prompt(text)
+
+        try:
+            raw = self.complete(prompt)
+        except Exception as e:
+            Config.logger.warning(
+                f"[{self.__class__.__name__}] check_expired completion failed: {e}"
+            )
+            return None
+
+        Config.logger.debug(f"[{self.__class__.__name__}] Raw expired-check response: {raw!r}")
+        cleaned = re.sub(r"^```(?:json)?|```$", "", raw, flags=re.MULTILINE).strip()
+
+        try:
+            data = json.loads(cleaned)
+        except json.JSONDecodeError:
+            data = _try_repair_json(cleaned)
+
+        if not isinstance(data, dict) or "expired" not in data:
+            Config.logger.warning(
+                f"[{self.__class__.__name__}] check_expired: no clear verdict in "
+                f"response (truncated): {cleaned[:200]!r}"
+            )
+            return None
+
+        return bool(data["expired"])
 
 
 # ─── Groq ──────────────────────────────────────────────────────────────────────

--- a/Refine/refine.py
+++ b/Refine/refine.py
@@ -76,10 +76,10 @@ async def enrich_unenriched_jobs(
     # Pull a batch of unenriched jobs
     rows = await db.select(
         table="job_list",
-        filters={"enriched": False},
-        order_by="created_at ASC",
+        filters={"enriched": False, "status": "active"},
+        order_by="created_at DESC",
         limit=batch_size,
-    )
+    ) #the idea is to always newer jobs first, so we can get the most recent jobs enriched first as they are the ones that are more likely to be relevant and useful for users. This way, we can prioritize enriching the jobs that are more likely to be applied to and increase the chances of successful placements.
     
     if not rows:
         Config.logger.info("Enrichment: no unenriched jobs found.")
@@ -90,7 +90,7 @@ async def enrich_unenriched_jobs(
     for i, row in enumerate(rows):
         stats["attempted"] += 1
         job_id = row["id"]
-        enricher = JobEnricher(provider=provider, use_llm=use_llm)
+        enricher = JobEnricher(job_id=job_id, provider=provider, use_llm=use_llm)
         # Fast-path: if nothing is actually missing, just mark enriched and move on
         if not _needs_enrichment(row):
             await _mark_enriched(db, job_id)

--- a/Service/Scrapper.py
+++ b/Service/Scrapper.py
@@ -1,10 +1,7 @@
 from bs4 import BeautifulSoup
-from typing import Optional
+from typing import Optional, Union
 
 from Utils.constants import Config
-import json, requests, asyncio, re
-from typing import Optional, Union
-from bs4 import BeautifulSoup
 import json, requests, asyncio, re
 
 
@@ -39,13 +36,20 @@ class Pirate:
             "log in to continue",
             "please sign in",
             "please enable javascript",
-            "access denied",
-            "403 forbidden",
-            "404 not found",
-            "just a moment",  # cloudflare
-            "checking your browser",  # cloudflare
+            "just a moment",  # cloudflare challenge page, served with a real 200
+            "checking your browser",  # cloudflare challenge page, served with a real 200
+            "are you a human",  # cloudflare
+            "workday is currently unavailable",  # Workday's own outage page,
+            "we are experiencing a service interruption",  # not the actual posting
             # Removed bare "sign in" / "log in" — these appear in legitimate
             # job descriptions for any auth/identity-related role.
+            # Removed "403 forbidden" / "404 not found" text signals — dead
+            # code in practice. A real 403/404 status raises via
+            # raise_for_status() (requests) or is visible on the Playwright
+            # response object before this classifier ever sees page text; by
+            # the time text classification runs, the status was already 200.
+            # Detecting a block/dead-link is now handled at the status-code
+            # level in scrape_apply_url instead (see BLOCKED_STATUS_CODES).
         ]
 
         self._SITE_EXPIRED_URL_PATTERNS = {
@@ -53,7 +57,30 @@ class Pirate:
             "myworkdayjobs.com": [r"/error", r"/notfound", r"sessionTimedOut"],
         }
 
-        self._HEADERS = {"User-Agent": "Mozilla/5.0 (compatible; JobBot/1.0)"}
+        # Status codes that mean "the site actively blocked this request"
+        # (bot detection, rate limiting) — NOT evidence the job is expired.
+        # These are surfaced distinctly so callers don't conflate "we got
+        # blocked" with "the listing is dead" or "something is broken".
+        self.BLOCKED_STATUS_CODES = {403, 429}
+
+        # A bare UA string with no other headers is a dead giveaway of
+        # non-browser traffic to even basic bot detection. This won't
+        # defeat a determined WAF (Cloudflare/PerimeterX-style JS challenges,
+        # TLS/JA3 fingerprinting) — nothing short of a real browser can — but
+        # it avoids being trivially flagged by simpler header-sniffing checks.
+        self._HEADERS = {
+            "User-Agent": (
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+                "(KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36"
+            ),
+            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+            "Accept-Language": "en-US,en;q=0.9",
+            "Upgrade-Insecure-Requests": "1",
+            "Sec-Fetch-Dest": "document",
+            "Sec-Fetch-Mode": "navigate",
+            "Sec-Fetch-Site": "none",
+            "Sec-Fetch-User": "?1",
+        }
 
     def _is_known_expired_redirect(self, final_url: str) -> bool:
         for domain, patterns in self._SITE_EXPIRED_URL_PATTERNS.items():
@@ -126,87 +153,139 @@ class Pirate:
 
     async def scrape_apply_url(self, url: str) -> Optional[Union[str, dict]]:
         """
-        Returns a dict if a schema.org JobPosting JSON-LD block was found
-        (authoritative, vendor-supplied — caller should overwrite, not merge),
-        a str if only rendered text could be scraped (treat as a hint —
-        caller should fill gaps via regex/LLM as before), or None on failure.
+        Returns:
+          - a dict with job_expired/description/etc if a schema.org JobPosting
+            JSON-LD block was found (authoritative — caller should overwrite,
+            not merge)
+          - a dict {"blocked": True, "status_code": ...} if the site actively
+            blocked the request (403/429) — this is NOT evidence the job is
+            expired, just that this scrape attempt was refused
+          - a str if only rendered text could be scraped (treat as a hint)
+          - None on any other failure (timeout, connection error, etc.)
         """
         try:
             from playwright.async_api import async_playwright
-            async with async_playwright() as p:
-                browser = await p.chromium.launch(headless=True)
-                page = await browser.new_page()
-                await page.goto(url, timeout=15000)
-                await page.wait_for_load_state("networkidle", timeout=15000)
-
-                if "myworkdayjobs.com" in url:
-                    try:
-                        await page.wait_for_selector(
-                            '[data-automation-id="jobPostingDescription"]', timeout=10000
-                        )
-                    except Exception:
-                        Config.logger.warning(
-                            "Workday job description selector never appeared — "
-                            "page may have failed to render or the listing is dead."
-                        )
-
-                if self._is_known_expired_redirect(page.url):
-                    Config.logger.warning(f"Known expired redirect detected: {page.url}")
-                    await browser.close()
-                    return None
-
-                html = await page.content()
-                jobposting = self._extract_jobposting_jsonld(html)
-                if jobposting:
-                    Config.logger.info("Found schema.org JobPosting JSON-LD — using structured data")
-                    await browser.close()  # was leaking on this path
-                    return self._jobposting_to_fields(jobposting)
-
-                if getattr(Config, "DEBUG_SCRAPE", False):
-                    await asyncio.to_thread(
-                        lambda: open("debug_page.html", "w", encoding="utf-8").write(html)
-                    )
-                    Config.logger.debug(f"Dumped raw page HTML ({len(html)} chars) to debug_page.html")
-
-                await page.evaluate(
-                    "document.querySelectorAll('nav,footer,header,script,style')"
-                    ".forEach(el => el.remove())"
-                )
-                await page.evaluate("""
-                    document.querySelectorAll(
-                        '[id*="cookie" i], [class*="cookie" i], ' +
-                        '[id*="consent" i], [class*="consent" i], ' +
-                        '[aria-label*="cookie" i]'
-                    ).forEach(el => el.remove())
-                """)
-
-                texts = []
-                for frame in page.frames:
-                    try:
-                        frame_text = await frame.inner_text("body")
-                        if frame_text:
-                            texts.append(frame_text)
-                    except Exception:
-                        continue
-
-                text = max(texts, key=len) if texts else ""
-                await browser.close()
-                Config.logger.info(
-                    f"Scraped with Playwright ({len(page.frames)} frame(s) checked) and length={len(text)}"
-                )
-                text = self._strip_cookie_boilerplate(text)
-                return Config.clean_ws(text)[:10000]
-
         except ImportError:
             Config.logger.warning("Playwright not installed — run: pip install playwright && playwright install chromium")
-        except Exception as e:
-            Config.logger.warning(f"Playwright failed: {e} — trying requests fallback")
+        else:
+            try:
+                async with async_playwright() as p:
+                    browser = await p.chromium.launch(
+                        headless=True,
+                        # Reduces (doesn't eliminate) trivial headless-detection
+                        # via the navigator.webdriver flag some bot checks look for.
+                        args=["--disable-blink-features=AutomationControlled"],
+                    )
+                    # try/finally guarantees this browser process is closed on
+                    # EVERY exit path — including a goto/networkidle timeout —
+                    # rather than relying on scattered .close() calls in except
+                    # blocks, which are easy to get wrong (e.g. calling .close()
+                    # on a browser that was never assigned, or closing one twice).
+                    try:
+                        context = await browser.new_context(
+                            user_agent=self._HEADERS["User-Agent"],
+                            viewport={"width": 1280, "height": 800},
+                            locale="en-US",
+                        )
+                        page = await context.new_page()
+
+                        # domcontentloaded, not networkidle, for the initial nav
+                        # — networkidle requires zero network activity for
+                        # 500ms, which analytics beacons, chat widgets, ad
+                        # pixels, or (on sites like ZipRecruiter) a bot-challenge
+                        # page's own background polling can prevent indefinitely
+                        # even though the actual content already rendered.
+                        response = await page.goto(url, timeout=15000, wait_until="domcontentloaded")
+
+                        if response is not None and response.status in self.BLOCKED_STATUS_CODES:
+                            Config.logger.warning(
+                                f"Blocked (HTTP {response.status}) loading {url} via Playwright"
+                            )
+                            return {"blocked": True, "status_code": response.status}
+
+                        # Best-effort only: give the page a shorter window to
+                        # go idle, but a page that never fully idles is common
+                        # and shouldn't discard an otherwise-successful scrape.
+                        try:
+                            await page.wait_for_load_state("networkidle", timeout=8000)
+                        except Exception:
+                            Config.logger.debug(
+                                f"{url}: networkidle not reached within budget — "
+                                "continuing anyway (common with polling/analytics)"
+                            )
+
+                        if "myworkdayjobs.com" in url:
+                            try:
+                                await page.wait_for_selector(
+                                    '[data-automation-id="jobPostingDescription"]', timeout=10000
+                                )
+                            except Exception:
+                                Config.logger.warning(
+                                    "Workday job description selector never appeared — "
+                                    "page may have failed to render or the listing is dead."
+                                )
+
+                        if self._is_known_expired_redirect(page.url):
+                            Config.logger.warning(f"Known expired redirect detected: {page.url}")
+                            return None
+
+                        html = await page.content()
+                        jobposting = self._extract_jobposting_jsonld(html)
+                        if jobposting:
+                            Config.logger.info("Found schema.org JobPosting JSON-LD — using structured data")
+                            return self._jobposting_to_fields(jobposting)
+
+                        if getattr(Config, "DEBUG_SCRAPE", False):
+                            await asyncio.to_thread(
+                                lambda: open("debug_page.html", "w", encoding="utf-8").write(html)
+                            )
+                            Config.logger.debug(f"Dumped raw page HTML ({len(html)} chars) to debug_page.html")
+
+                        await page.evaluate(
+                            "document.querySelectorAll('nav,footer,header,script,style')"
+                            ".forEach(el => el.remove())"
+                        )
+                        await page.evaluate("""
+                            document.querySelectorAll(
+                                '[id*="cookie" i], [class*="cookie" i], ' +
+                                '[id*="consent" i], [class*="consent" i], ' +
+                                '[aria-label*="cookie" i]'
+                            ).forEach(el => el.remove())
+                        """)
+
+                        texts = []
+                        for frame in page.frames:
+                            try:
+                                frame_text = await frame.inner_text("body")
+                                if frame_text:
+                                    texts.append(frame_text)
+                            except Exception:
+                                continue
+
+                        text = max(texts, key=len) if texts else ""
+                        Config.logger.info(
+                            f"Scraped with Playwright ({len(page.frames)} frame(s) checked) and length={len(text)}"
+                        )
+                        text = self._strip_cookie_boilerplate(text)
+                        return Config.clean_ws(text)[:10000]
+                    finally:
+                        await browser.close()
+            except Exception as e:
+                Config.logger.warning(f"Playwright failed: {e} — trying requests fallback")
 
         try:
             resp = requests.get(url, headers=self._HEADERS, timeout=10)
+
+            if resp.status_code in self.BLOCKED_STATUS_CODES:
+                Config.logger.warning(
+                    f"Blocked (HTTP {resp.status_code}) requesting {url} — treating as blocked, not expired"
+                )
+                return {"blocked": True, "status_code": resp.status_code}
+
             if self._is_known_expired_redirect(resp.url):
                 Config.logger.warning(f"Known expired redirect detected for URL: {resp.url}")
                 return None
+
             resp.raise_for_status()
             soup = BeautifulSoup(resp.text, "html.parser")
 

--- a/Service/azalea.py
+++ b/Service/azalea.py
@@ -204,9 +204,10 @@ class Azalea:
                 Config.logger.warning("TEST MODE: loading jobs from local JSON, skipping fetch & dedup")
                 try:
                     with open(FilePaths.SCRAPED_JOBS_JSON, "r", encoding="utf-8") as f:
-                        list_jobs = json.load(f)[:20]  # type: ignore
+                        list_jobs = json.load(f)[:5]  # type: ignore
                         for job_dict in list_jobs:
                             try:
+                                Config.logger.info(f"Loading job from JSON: {job_dict.get('title', 'unknown')} at {job_dict.get('company', 'unknown')}")
                                 company_id = UUID(job_dict.get("company", None))
                                 job = Job.from_dict(job_dict, company=company_id)
                                 self.jobs.append(job)
@@ -222,14 +223,22 @@ class Azalea:
             # ── Step 4: Insert to DB ─────────────────────────────────────────
             self._log_section("SAVING TO DATABASE")
             db = await JobDatabase.create()
-            fin_jobs = [job.to_dict_for_db(job) for job in self.jobs if job.title != "unknown"]
+            domains_to_ignore = {"ziprecruiter"}
+            # Domains we skip when inserting — sites that reliably block scraping
+            # (bot-check pages, 403s) so enrichment/expiry checks can never get a
+            # real read on them. Add more as needed.
+            fin_jobs = [
+                job.to_dict_for_db(job)
+                for job in self.jobs
+                if job.title != "unknown"
+                and job.apply_url
+                and not any(domain in job.apply_url for domain in domains_to_ignore)
+            ]
             if not fin_jobs:
                 Config.logger.warning("No valid jobs to insert into the database")
                 return self.stats.to_dict()
-            inserted = await db.bulk_upsert(
-                "job_list", fin_jobs , conflict_column=["title", "company", "apply_url"]
-            )
-            self.stats.inserted = len(inserted)
+            inserted = await db.bulk_upsert("job_list", fin_jobs , conflict_column=["title", "company", "apply_url"])
+            self.stats.inserted = len(inserted) #note this isnt a perfect measure of how many new jobs were inserted, as some may have been updated instead of inserted, but it gives us a rough idea of how many jobs were processed and saved to the database. We can improve this later by checking the returned rows for any indication of whether they were inserted or updated. 
             Config.logger.info(
                 f"Inserted {self.stats.inserted} new jobs into the database"
             )
@@ -240,10 +249,11 @@ class Azalea:
             #    enrich_stats = await enrich_unenriched_jobs(batch_size=enrich_batch_size)
             #    Config.logger.info(f"Enrichment stats: {enrich_stats}")
             #using the test mode to only test the enrichment process, we can enable this later when we have more confidence in the enrichment code
-            # the task/ will take care of actaully calling and enricnhng the jobs, we just want to test the enrichment code here without having to run the whole fetch/dedup process every time
+            # the task/ will take care of actually calling and enricnhng the jobs, we just want to test the enrichment code here without having to run the whole fetch/dedup process every time
             if test:
-                self._log_section("ENRICHING JOBS (Groq)")
-                enrich_stats = await enrich_unenriched_jobs(batch_size=20)
+                self._log_section("ENRICHING JOBS ")
+                
+                enrich_stats = await enrich_unenriched_jobs(batch_size=5)
                 Config.logger.info(f"Enrichment stats: {enrich_stats}")
                 self.print_summary()
             return self.stats.to_dict()
@@ -260,7 +270,7 @@ def main():
     orchestrator = Azalea()
 
     try:
-        asyncio.run(orchestrator.run(position_type=PositionType.INTERN, save_json=True))
+        asyncio.run(orchestrator.run(position_type=PositionType.INTERN, save_json=True,test=True))
 
     except Exception as e:
         err_msg = f"❌ Libra scraper failed:\n```{str(e)}```"

--- a/Tasks/expired.py
+++ b/Tasks/expired.py
@@ -1,0 +1,307 @@
+"""
+Weekly expiry checker.
+
+Three escalating tiers, cheapest first — most jobs should resolve at tier 1
+and never touch Playwright or the LLM:
+
+  Tier 1 (cheap):   HEAD, falling back to a small GET, against apply_url.
+                     Catches dead status codes (404/410) and redirects to
+                     known "expired" URL shapes almost for free. Known
+                     JS-rendered ATS domains (Workday, Ashby, etc.) skip
+                     text classification here entirely and escalate straight
+                     to tier 2 — their raw HTML is an empty SPA shell
+                     regardless of whether the listing is alive or dead, so
+                     trusting it produces confident false negatives.
+  Tier 2 (scrape):   Only runs if tier 1 is inconclusive (e.g. a JS-rendered
+                     ATS page that always 200s). Reuses Pirate.scrape_apply_url
+                     — the same Playwright scraper the enricher uses — and
+                     Pirate.classify_scraped_text() to catch "posting closed"
+                     wording that a raw HTTP check can't see.
+  Tier 3 (LLM):      Only runs if tier 2's scraped text still doesn't clearly
+                     say expired/garbage. Calls provider.check_expired() — a
+                     dedicated, narrow prompt that takes only the scraped
+                     text and asks a single yes/no question, no Job object
+                     and no other fields extracted or written.
+
+Unlike JobEnricher, this never fills in missing fields — it only ever
+flips status -> "expired". Jobs it can't confidently classify at any tier
+are left untouched, and already-expired jobs are excluded by the query
+itself, so re-running this weekly is safe and idempotent.
+"""
+
+import asyncio
+import uuid
+from typing import Optional
+
+import aiohttp
+from bs4 import BeautifulSoup
+
+from Utils.constants import Config
+from Refine.llm import LLMProvider, OllamaProvider
+from Service.Scrapper import Pirate
+from Service.db import JobDatabase
+
+
+class ExpiryChecker:
+    """Escalating, expired-only re-validation pass over non-expired jobs."""
+
+    TIMEOUT = aiohttp.ClientTimeout(total=8)
+    DEAD_STATUS_CODES = {404, 410}
+    GET_BYTE_LIMIT = 20_000  # tier 1's GET fallback only sniffs the first N bytes
+    USER_AGENT = "Mozilla/5.0 (compatible; LibraExpiryChecker/1.0)"
+
+    DEFAULT_HTTP_CONCURRENCY = 10   # tier 1 — cheap, can run wide
+    DEFAULT_HEAVY_CONCURRENCY = 2   # tiers 2/3 — Playwright + LLM, keep narrow
+
+    # Platforms that render the job page client-side via JS. A plain GET on
+    # these returns an (almost) empty SPA shell — no "job not found" text,
+    # but also no real posting content — regardless of whether the listing
+    # is alive or dead. Classifying that raw shell as "ok" is a confident
+    # false negative (see: 4/5 Workday/Ashby jobs misreported as active in
+    # a real run). Skip tier 1's text classification for these domains and
+    # go straight to tier 2 (Playwright), which actually renders the page.
+    SPA_ONLY_DOMAINS = (
+        "myworkdayjobs.com",
+        "ashbyhq.com",
+        "greenhouse.io",
+        "lever.co",
+        "smartrecruiters.com",
+    )
+
+    def __init__(
+        self,
+        provider: Optional[LLMProvider] = None,
+        use_llm: bool = True,
+        llm_delay: float = 0.5,
+    ):
+        self.http_semaphore = asyncio.Semaphore(self.DEFAULT_HTTP_CONCURRENCY)
+        self.heavy_semaphore = asyncio.Semaphore(self.DEFAULT_HEAVY_CONCURRENCY)
+        self.pirate = Pirate()
+        self.use_llm = use_llm
+        self.provider = provider or (OllamaProvider() if use_llm else None)
+        self.llm_delay = llm_delay
+
+        self.metrics = {
+            "checked": 0,
+            "newly_expired": 0,
+            "failed": 0,
+            "blocked": 0,
+            "resolved_tier1": 0,
+            "resolved_tier2": 0,
+            "resolved_tier3": 0,
+        }
+
+    # ─── Tier 1: cheap HTTP check ──────────────────────────────────────────
+
+    def _is_spa_only_domain(self, url: str) -> bool:
+        return any(domain in url for domain in self.SPA_ONLY_DOMAINS)
+
+    def _redirect_looks_expired(self, original_url: str, final_url: str) -> bool:
+        if final_url == original_url:
+            return False
+        # Reuses whatever pattern set Pirate already maintains for expired-URL
+        # detection, so this stays a single source of truth with the enricher.
+        return self.pirate._is_known_expired_redirect(final_url)
+
+    @staticmethod
+    def _visible_text(html: str) -> str:
+        """
+        Strip tags/scripts/styles so classify_scraped_text() is judging the
+        same kind of input here as it does everywhere else (Pirate always
+        hands it rendered or BeautifulSoup-extracted text, never raw markup).
+        Raw HTML is long and script/style-heavy enough to dodge both the
+        "garbage" length check and every phrase match by accident.
+        """
+        soup = BeautifulSoup(html, "html.parser")
+        for tag in soup(["nav", "footer", "script", "style", "header"]):
+            tag.decompose()
+        return soup.get_text(separator=" ")
+
+    async def _cheap_check(self, session: aiohttp.ClientSession, url: str) -> Optional[bool]:
+        """True/False if confident, None if inconclusive (escalate to tier 2)."""
+        headers = {"User-Agent": self.USER_AGENT}
+
+        try:
+            async with session.head(
+                url, allow_redirects=True, timeout=self.TIMEOUT, headers=headers
+            ) as resp:
+                if resp.status in self.DEAD_STATUS_CODES:
+                    return True
+                if self._redirect_looks_expired(url, str(resp.url)):
+                    return True
+                if resp.status == 200:
+                    # A 200 alone isn't proof of life — many ATS pages 200 a
+                    # "posting closed" shell. Fall through to a text sniff via
+                    # GET rather than trusting the status code in isolation.
+                    pass
+        except (aiohttp.ClientError, asyncio.TimeoutError):
+            pass  # some ATSes reject HEAD outright — fall through to GET
+
+        try:
+            async with session.get(
+                url, allow_redirects=True, timeout=self.TIMEOUT, headers=headers
+            ) as resp:
+                if resp.status in self.DEAD_STATUS_CODES:
+                    return True
+                if self._redirect_looks_expired(url, str(resp.url)):
+                    return True
+                if resp.status != 200:
+                    return None  # ambiguous status — don't guess
+
+                # Known JS-rendered ATS platforms: their raw HTML is a near-
+                # empty SPA shell whether the job is live or dead. There is
+                # nothing here worth classifying — escalate straight to
+                # tier 2, which can actually render the page.
+                if self._is_spa_only_domain(str(resp.url)):
+                    return None
+
+                chunk = await resp.content.read(self.GET_BYTE_LIMIT)
+                raw = chunk.decode(errors="ignore")
+                text = self._visible_text(raw)
+                status = self.pirate.classify_scraped_text(text)
+                if status == "expired":
+                    return True
+                if status == "garbage":
+                    # Not enough real text to go on either way — likely a
+                    # JS-rendered page we don't have a domain rule for yet.
+                    # Escalate rather than assume.
+                    return None
+                return False
+        except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+            Config.logger.warning(f"Tier 1 check failed for {url}: {e}")
+            return None
+
+    # ─── Tiers 2/3: Playwright scrape, then LLM — expired signal only ─────
+
+    async def _deep_check(self, apply_url: str) -> Optional[bool]:
+        """
+        Escalation path for jobs tier 1 couldn't resolve. Runs the same
+        Playwright scrape the enricher uses, then the LLM if needed — but
+        only ever looks at the job_expired signal via check_expired(), never
+        fills other fields and never needs a Job object.
+        """
+        scraped = await self.pirate.scrape_apply_url(apply_url)  # type: ignore
+        print(f"Scraped data for {apply_url}: {scraped}")  # Debugging line
+        if scraped is None:
+            return None
+
+        if isinstance(scraped, dict):
+            # A block (403/429) is NOT evidence the job is expired — just
+            # that this scrape attempt was refused. Count it separately so
+            # "site is blocking us" doesn't get buried in a generic failed
+            # count, and definitely doesn't get treated as expired.
+            if scraped.get("blocked"):
+                self.metrics["blocked"] += 1
+                Config.logger.warning(
+                    f"Scrape blocked (HTTP {scraped.get('status_code')}) for {apply_url}"
+                )
+                return None
+
+            # Structured (schema.org JobPosting JSON-LD) data — treat as
+            # authoritative, same as the enricher does. Only count this as
+            # tier-2-resolved if it actually yields a verdict; if job_expired
+            # is missing/None, this still falls through to the LLM and tier 3
+            # gets the credit.
+            if scraped.get("job_expired"):
+                self.metrics["resolved_tier2"] += 1
+                return True
+            if scraped.get("job_expired") is False:
+                self.metrics["resolved_tier2"] += 1
+                return False
+            text_for_llm = scraped.get("description")
+        else:
+            status = self.pirate.classify_scraped_text(scraped)
+            if status == "expired":
+                self.metrics["resolved_tier2"] += 1
+                return True
+            if status == "garbage":
+                return None  # still nothing usable — give up rather than guess
+            text_for_llm = scraped
+
+        if not (self.use_llm and self.provider and text_for_llm):
+            return None
+
+        # Dedicated, narrow LLM call — just the expired signal, no Job
+        # object needed and no other fields extracted or written.
+        is_expired = self.provider.check_expired(text_for_llm)
+        if is_expired is None:
+            return None  # model gave no clear verdict — stay inconclusive
+        self.metrics["resolved_tier3"] += 1
+        return is_expired
+
+    # ─── Orchestration ─────────────────────────────────────────────────────
+
+    async def _check_one(self, session: aiohttp.ClientSession, job: dict) -> tuple[uuid.UUID, Optional[bool]]:
+        job_id = job.get("id")
+        url = job.get("apply_url")
+        if not url:
+            return job_id, None  # type: ignore
+
+        async with self.http_semaphore:
+            result = await self._cheap_check(session, url)
+            print(f"Tier 1 result for job {job_id} ({url}): {result}")  # Debugging line
+        if result is not None:
+            self.metrics["resolved_tier1"] += 1
+            return job_id, result  # type: ignore
+
+        async with self.heavy_semaphore:
+            result = await self._deep_check(url)
+            if self.use_llm:
+                await asyncio.sleep(self.llm_delay)  # respect free-tier/rate limits
+        return job_id, result  # type: ignore
+
+    async def run(self, db: "JobDatabase") -> dict:
+        """
+        Query every job not currently marked expired, run the tiered check
+        against each, and flip newly-expired ones. Returns the metrics dict.
+        """
+        jobs = await db.select(
+            table="job_list",
+            filters={"status": "active"},
+            columns=["id", "apply_url"],
+        )
+
+        Config.logger.info(f"Weekly expiry check: {len(jobs)} non-expired jobs to check")
+
+        async with aiohttp.ClientSession() as session:
+            tasks = [self._check_one(session, job) for job in jobs]
+            results = await asyncio.gather(*tasks)
+
+        newly_expired_ids = []
+        for job_id, is_expired in results:
+            self.metrics["checked"] += 1
+            if is_expired is None:
+                self.metrics["failed"] += 1
+            elif is_expired:
+                self.metrics["newly_expired"] += 1
+                newly_expired_ids.append(job_id)
+
+        if newly_expired_ids:
+            # Skip the round trip entirely when nothing changed, rather than
+            # issuing an UPDATE ... WHERE id = ANY($1) with an empty array.
+            await db.raw(
+                sql="UPDATE job_list SET status = 'expired' WHERE id = ANY($1)",
+                params=[newly_expired_ids],
+            )
+
+        Config.logger.info(
+            f"Weekly expiry check done — checked: {self.metrics['checked']}, "
+            f"newly expired: {self.metrics['newly_expired']}, "
+            f"failed: {self.metrics['failed']}, "
+            f"blocked: {self.metrics['blocked']} "
+            f"(tier1: {self.metrics['resolved_tier1']}, "
+            f"tier2: {self.metrics['resolved_tier2']}, "
+            f"tier3: {self.metrics['resolved_tier3']})"
+        )
+        return self.metrics
+
+
+async def run_weekly_expiry_check() -> dict:
+    """Entry point for the scheduled (cron/systemd timer) job."""
+    db = await JobDatabase.create()
+    checker = ExpiryChecker()
+    return await checker.run(db)
+
+
+if __name__ == "__main__":
+    asyncio.run(run_weekly_expiry_check())

--- a/Utils/models.py
+++ b/Utils/models.py
@@ -94,6 +94,8 @@ class Job:
             raise ValueError("Company must be a UUID representing the company ID")
         if not self.location:
             self.location = "Unknown"
+        if self.apply_url:
+            self.apply_url = self.strip_URL_query_params()
 
     def is_valid(self) -> bool:
         return bool(
@@ -114,6 +116,11 @@ class Job:
         val = min_sal if min_sal is not None else max_sal
         return f"${val:,}+"
 
+    def strip_URL_query_params(self) -> str | None:
+        if self.apply_url:
+            return self.apply_url.split("?", 1)[0]
+        return None
+            
     @classmethod
     def from_dict(cls, job: dict, company: uuid.UUID|None) -> "Job":
         """
@@ -189,7 +196,6 @@ class Job:
 
     def __hash__(self):
         return hash((self.title, self.company, self.location, self.apply_url))
-    
     @staticmethod
     def build_job_embed(job: dict) -> dict:
         tags = job.get("tags") or {}

--- a/docs/diagrams/extractor_class.md
+++ b/docs/diagrams/extractor_class.md
@@ -3,6 +3,7 @@
 classDiagram
     class JobEnricher {
         +provider: LLMProvider
+        +job_id: uuid.UUID
         +use_llm: bool
         +llm_delay: float
         +fields_to_check: list~str~
@@ -17,7 +18,7 @@ classDiagram
         -_run_regex(job) None
         -_run_scrape(job) None
         -_handle_scraped_text(job, scraped) dict
-        -_mark_expired(job) None
+        -_mark_expired() None
     }
 
     class RegexConstants {

--- a/docs/diagrams/llm_class.md
+++ b/docs/diagrams/llm_class.md
@@ -5,6 +5,7 @@ classDiagram
         <<abstract>>
         +complete(prompt: str) str*
         +extract(job: Job, text: str) dict
+        +_build_expired_check_prompt(text: str) str
     }
 
     class OllamaProvider {

--- a/docs/diagrams/models_class.md
+++ b/docs/diagrams/models_class.md
@@ -19,6 +19,7 @@ classDiagram
         +to_dict(job) dict$
         +to_dict_for_db(job) dict$
         +build_job_embed(job) dict$
+        +strip_URL_query_params()
         +__eq__(other) bool
         +__hash__() int
     }

--- a/main.py
+++ b/main.py
@@ -69,7 +69,7 @@ async def get_jobs(
 ):
     """Get all jobs ordered by most recent, with an optional limit."""
     db: JobDatabase = request.app.state.db
-    jobs = await db.select("job_list", order_by="created_at DESC", limit=limit)#type: ignore
+    jobs = await db.select("job_list",filters={"enriched": True, "status": "active"}, order_by="created_at ASC", limit=limit)#type: ignore
     return {
         "success": True,
         "params": {"limit": limit},
@@ -87,9 +87,9 @@ async def get_jobs_by_company(
     db: JobDatabase = request.app.state.db
     jobs = await db.select(
         "job_list",
-        raw_where="company = (SELECT id FROM company WHERE name = $1)",
+        raw_where="company = (SELECT id FROM company WHERE name = $1) AND enriched = true AND status = 'active'",
         raw_params=[company_name.lower()],
-        order_by="created_at DESC",
+        order_by="created_at ASC",
         limit=limit, #type: ignore
     )
     return {
@@ -105,9 +105,9 @@ async def search_jobs(keyword: str, request: Request):
     db: JobDatabase = request.app.state.db
     jobs = await db.select(
         "job_list",
-        raw_where="lower(title) LIKE $1",
+        raw_where="lower(title) LIKE $1 AND enriched = true AND status = 'active'",
         raw_params=[f"%{keyword.lower()}%"],
-        order_by="created_at DESC",
+        order_by="created_at ASC",
     )
     return {
         "success": True,
@@ -122,7 +122,7 @@ async def get_jobs_by_sponsorship(request: Request):
     db: JobDatabase = request.app.state.db
     jobs = await db.select(
         "job_list",
-        raw_where="tags->>'sponsorship' = 'true'",
+        raw_where="tags->>'sponsorship' = 'true' AND enriched = true AND status = 'active'",
         order_by="created_at DESC",
     )
     return {


### PR DESCRIPTION
Introduce a weekly expiry checker and tighten the expiry/scrape/LLM pipeline.

- Add Tasks/expired.py: ExpiryChecker with 3-tier checks (HEAD/GET, Playwright scrape, narrow LLM check) and DB update of expired jobs.
- Refine JobEnricher to accept job_id, make _mark_expired async and update the DB, and wire job_id through callers (refine.enrich_unenriched_jobs).
- Refine.llm: add check_expired() and prompt builder for a narrow expired/no-expired boolean check.
- Service.Scrapper (Pirate): improved Playwright handling, safer browser/context lifecycle, stronger headers, blocked-status detection (returns {blocked: True, status_code}), and requests fallback handling.
- Service.azalea: reduce test batch sizes, skip problematic domains when inserting, log more info, and run orchestrator in test mode.
- Utils.models.Job: add strip_URL_query_params() and sanitize apply_url on init.
- main.py: API endpoints now return only enriched, active jobs and adjust ordering.
- Update class diagrams/docs to reflect new fields and methods.

Also minor changes: prioritize newer jobs for enrichment and other small logging/debug additions.

## What does this PR change?

Fixes the issue #22 

## Checklist

### If you touched `Refine/`, `Service/Scrapper.py`, or `Utils/sanitate.py`
- [x] Regenerated the matching `docs/diagrams/*_class.md` and `*_seq.md` for any changed class/function — don't leave them describing the old shape (this has happened twice: once when `extractor.py` became `JobEnricher`, once when `azalea.py`'s `list_jobs`/`fin_jobs` changed)
- [x] If a class holds mutable state built in `__init__` (like `JobEnricher.meta`), confirm callers create a fresh instance per unit of work, not one shared instance reused across a loop
- [x] If you added/changed a field the LLM can return, updated `LLMConstants._LLM_PROMPT` **and** the matching sanitizer method in `Utils/sanitate.py`

### If you touched `Service/azalea.py` or anything in the scrape → DB path
- [x] Confirmed `Job.to_dict()` (JSON backup shape) and `Job.to_dict_for_db()` (Postgres shape) aren't mixed up — anything reaching `bulk_upsert`/`upsert` should go through `to_dict_for_db()`
- [x] If you added a new mode/branch (like `test=True`), confirmed it converges on the same DB-insert step as the normal path, rather than duplicating (and potentially diverging from) it

### If you changed the DB schema (new column, changed type, etc.)
- [x] Added the `ALTER TABLE`/`CREATE TABLE` change to `wiki/Database-Layer.md` and the README's schema block — this repo has no `migrations/` folder, so these two places are the only record of what a fresh DB needs (this bit us with `enrich_attempts`)

### If you changed anything covered by the wiki
- [x] Updated the actual page under `wiki/` (not just the diagrams) — `Home.md` specifically is easy to forget since it doesn't get touched by most module-level changes, but it's the landing page
- [x] Searched the changed wiki pages for now-wrong terminology (e.g. a provider/library swap leaving stale references to the old one)

### Before merging
- [x] Ran the actual code path this PR touches, not just read it — an import succeeding isn't the same as the logic being correct (e.g. the `azalea.py` test-mode bug didn't crash, it just silently inserted the wrong data shape)
- [x] If you added a Mermaid diagram or edited one, validated the syntax actually parses (GitHub's renderer will silently show a parse error otherwise) — Mermaid sequence diagrams don't support `try`/`catch`; use `alt`/`else` instead