### PR TITLE
Update scrape.yaml

### DIFF
--- a/.github/workflows/scrape.yaml
+++ b/.github/workflows/scrape.yaml
@@ -84,4 +84,53 @@ jobs:
            curl -H "Content-Type: application/json" \
            -d "{\"content\": \":x: <@755872891601551511>\nLibra **enrich** failed for **${{ github.repository }}** @ **${{ github.ref_name }}**\"}" \
            ${{ secrets.DISCORD_WEBHOOK }}
-  
+    
+  expired:
+    name: Expire Jobs
+    runs-on: ubuntu-latest
+    if: github.event.schedule == '0 6 * * 6' || github.event_name == 'workflow_dispatch'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run expiration via SSH and notify Discord with logs
+        uses: appleboy/ssh-action@v0.1.7
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          REPO: ${{ github.repository }}
+          REF: ${{ github.ref_name }}
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          envs: DISCORD_WEBHOOK,REPO,REF
+          script: |
+            set -uo pipefail   # no -e: a failing python run must not skip the notify step below
+
+            if [ ! -d /var/www/libra ]; then
+              echo "Directory /var/www/libra does not exist, skipping."
+              exit 0
+            fi
+
+            cd /var/www/libra/
+            source libra/bin/activate
+            mkdir -p logs
+            LOG_FILE=logs/expired.log
+
+            PYTHONPATH=/var/www/libra python3 Tasks/expired.py > "$LOG_FILE" 2>&1
+            STATUS=$?
+
+            if [ $STATUS -eq 0 ]; then
+              MSG=":white_check_mark: <@755872891601551511>\nLibra **expire** succeeded for **${REPO}** @ **${REF}**"
+            else
+              MSG=":x: <@755872891601551511>\nLibra **expire** failed for **${REPO}** @ **${REF}**"
+            fi
+
+            curl -sS \
+              -F "payload_json={\"content\": \"${MSG}\"}" \
+              -F "file1=@${LOG_FILE}" \
+              "${DISCORD_WEBHOOK}"
+
+            exit $STATUS
+
+     


### PR DESCRIPTION
## What does this PR change?

Created a CI/CD for the expired check

## Checklist

### If you touched `Refine/`, `Service/Scrapper.py`, or `Utils/sanitate.py`
- [x] Regenerated the matching `docs/diagrams/*_class.md` and `*_seq.md` for any changed class/function — don't leave them describing the old shape (this has happened twice: once when `extractor.py` became `JobEnricher`, once when `azalea.py`'s `list_jobs`/`fin_jobs` changed)
- [x] If a class holds mutable state built in `__init__` (like `JobEnricher.meta`), confirm callers create a fresh instance per unit of work, not one shared instance reused across a loop
- [x] If you added/changed a field the LLM can return, updated `LLMConstants._LLM_PROMPT` **and** the matching sanitizer method in `Utils/sanitate.py`

### If you touched `Service/azalea.py` or anything in the scrape → DB path
- [x] Confirmed `Job.to_dict()` (JSON backup shape) and `Job.to_dict_for_db()` (Postgres shape) aren't mixed up — anything reaching `bulk_upsert`/`upsert` should go through `to_dict_for_db()`
- [x] If you added a new mode/branch (like `test=True`), confirmed it converges on the same DB-insert step as the normal path, rather than duplicating (and potentially diverging from) it

### If you changed the DB schema (new column, changed type, etc.)
- [x] Added the `ALTER TABLE`/`CREATE TABLE` change to `wiki/Database-Layer.md` and the README's schema block — this repo has no `migrations/` folder, so these two places are the only record of what a fresh DB needs (this bit us with `enrich_attempts`)

### If you changed anything covered by the wiki
- [x] Updated the actual page under `wiki/` (not just the diagrams) — `Home.md` specifically is easy to forget since it doesn't get touched by most module-level changes, but it's the landing page
- [x] Searched the changed wiki pages for now-wrong terminology (e.g. a provider/library swap leaving stale references to the old one)

### Before merging
- [x] Ran the actual code path this PR touches, not just read it — an import succeeding isn't the same as the logic being correct (e.g. the `azalea.py` test-mode bug didn't crash, it just silently inserted the wrong data shape)
- [x] If you added a Mermaid diagram or edited one, validated the syntax actually parses (GitHub's renderer will silently show a parse error otherwise) — Mermaid sequence diagrams don't support `try`/`catch`; use `alt`/`else` instead