### PR TITLE
Notify Discord with embed on expiry run

### DIFF
--- a/.github/workflows/Automations.yaml
+++ b/.github/workflows/Automations.yaml
@@ -1,4 +1,5 @@
-name: Job Scraper Automation
+# This workflow is triggered on a schedule and runs the scraper, enrichment, and expiration tasks on a remote server via SSH. It also notifies a Discord channel on failure or success of the tasks.
+name: Automation
 
 on:
   schedule:
@@ -116,6 +117,9 @@ jobs:
             source libra/bin/activate
             mkdir -p logs
             LOG_FILE=logs/expired.log
+            
+            git fetch origin
+            git reset --hard origin/master
 
             PYTHONPATH=/var/www/libra python3 Tasks/expired.py > "$LOG_FILE" 2>&1
             STATUS=$?

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -6,7 +6,7 @@
 # - Restarts API with systemd
 # - Discord notifications
 # =========================================
-name: Libra API CI/CD
+name: Libra Deploy CI/CD
 
 on:
   push:

--- a/.github/workflows/notify.yaml
+++ b/.github/workflows/notify.yaml
@@ -1,4 +1,5 @@
-name: Libra API CI/CD
+#This is a GitHub Actions workflow that notifies a Discord channel when a new issue is opened, reopened, or closed in the repository. It also notifies the channel on push events, indicating whether the deployment was successful or failed.
+name: Issues Notification  CI/CD
 
 on:
   push:

--- a/Tasks/enrich.py
+++ b/Tasks/enrich.py
@@ -12,8 +12,8 @@ from Utils.notify import notify_discord
 from Service.db import JobDatabase
 
 async def main():
-    #await enrich_unenriched_jobs()
-    #notify_discord("Enrichment process completed successfully.", file_path="logs/enrich.log")
+    await enrich_unenriched_jobs()
+    notify_discord("Enrichment process completed successfully.", file_path="logs/enrich.log")
     db = await JobDatabase.create()
     columns = ["title", "location", "is_remote", "description", "apply_url", "role_type", "pay_range", "source", "tags"]
     job_list = await db.select(table="job_list", columns=columns, limit=10, order_by="updated_at DESC")

--- a/Tasks/expired.py
+++ b/Tasks/expired.py
@@ -30,18 +30,19 @@ itself, so re-running this weekly is safe and idempotent.
 """
 
 import asyncio
+from datetime import timezone
+import datetime
 import uuid
 from typing import Optional
 
 import aiohttp
 from bs4 import BeautifulSoup
-
 from Utils.constants import Config
 from Refine.llm import LLMProvider, OllamaProvider
 from Service.Scrapper import Pirate
 from Service.db import JobDatabase
-
-
+from Utils.notify import notify_discord
+from datetime import datetime, timezone
 class ExpiryChecker:
     """Escalating, expired-only re-validation pass over non-expired jobs."""
 
@@ -296,11 +297,29 @@ class ExpiryChecker:
         return self.metrics
 
 
-async def run_weekly_expiry_check() -> dict:
+async def run_weekly_expiry_check() -> None:
     """Entry point for the scheduled (cron/systemd timer) job."""
     db = await JobDatabase.create()
     checker = ExpiryChecker()
-    return await checker.run(db)
+    results = await checker.run(db)
+    embed = {
+        "title": "Weekly Expiry Check ",
+        "color": 0x5865F2 if not results['failed'] and not results['blocked'] else 0xE67E22,
+        "fields": [
+            {"name": "Checked", "value": str(results['checked']), "inline": True},
+            {"name": "Newly Expired", "value": str(results['newly_expired']), "inline": True},
+            {"name": "Failed", "value": str(results['failed']), "inline": True},
+            {"name": "Blocked", "value": str(results['blocked']), "inline": True},
+            {"name": "Tier 1", "value": str(results['resolved_tier1']), "inline": True},
+            {"name": "Tier 2", "value": str(results['resolved_tier2']), "inline": True},
+            {"name": "Tier 3", "value": str(results['resolved_tier3']), "inline": True},
+        ],
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+
+    notify_discord(embed=embed)
+    
+  
 
 
 if __name__ == "__main__":

--- a/Utils/notify.py
+++ b/Utils/notify.py
@@ -1,25 +1,32 @@
 import os
+from datetime import datetime, timezone
 
 import requests
 from Utils.constants import Config
 
-def notify_discord(message: str, file_path: str = ''):
+def notify_discord(message: str = '', file_path: str = '', embed: dict = None): #type: ignore
     webhook_url = Config.DISCORD_WEBHOOK
     if not webhook_url:
         Config.logger.warning("No Discord webhook found. Skipping.")
         return
+
+    payload = {}
+    if message:
+        payload["content"] = message
+    if embed:
+        payload["embeds"] = [embed]
 
     try:
         if file_path:
             with open(file_path, "rb") as f:
                 response = requests.post(
                     webhook_url,
-                    data={"content": message},        # message goes in data=
-                    files={"file": (os.path.basename(file_path), f)}  # file goes in files=
+                    data={"payload_json": requests.utils.json.dumps(payload)}, #type: ignore
+                    files={"file": (os.path.basename(file_path), f)}
                 )
         else:
-            response = requests.post(webhook_url, json={"content": message})
-        
+            response = requests.post(webhook_url, json=payload)
+
         response.raise_for_status()
     except Exception as e:
         Config.logger.error(f"Failed to send Discord notification: {e}")


### PR DESCRIPTION


## What does this PR change?

Refactor notify_discord to accept optional embeds and build a payload (supports message + file attachments). Tasks/expired.py now constructs and posts a summary embed after the weekly expiry check (checked, newly_expired, failed, blocked, resolved tiers, timestamp). Tasks/enrich.py now runs enrichment and sends completion notifications. GitHub Actions workflows renamed/clarified (scrape->Automations, updated names) and Automations workflow adds a git fetch/reset before running the expiry task. Minor import/formatting tweaks across files.

## Checklist

### If you touched `Refine/`, `Service/Scrapper.py`, or `Utils/sanitate.py`
- [x] Regenerated the matching `docs/diagrams/*_class.md` and `*_seq.md` for any changed class/function — don't leave them describing the old shape (this has happened twice: once when `extractor.py` became `JobEnricher`, once when `azalea.py`'s `list_jobs`/`fin_jobs` changed)
- [x] If a class holds mutable state built in `__init__` (like `JobEnricher.meta`), confirm callers create a fresh instance per unit of work, not one shared instance reused across a loop
- [x] If you added/changed a field the LLM can return, updated `LLMConstants._LLM_PROMPT` **and** the matching sanitizer method in `Utils/sanitate.py`

### If you touched `Service/azalea.py` or anything in the scrape → DB path
- [x] Confirmed `Job.to_dict()` (JSON backup shape) and `Job.to_dict_for_db()` (Postgres shape) aren't mixed up — anything reaching `bulk_upsert`/`upsert` should go through `to_dict_for_db()`
- [x] If you added a new mode/branch (like `test=True`), confirmed it converges on the same DB-insert step as the normal path, rather than duplicating (and potentially diverging from) it

### If you changed the DB schema (new column, changed type, etc.)
- [x] Added the `ALTER TABLE`/`CREATE TABLE` change to `wiki/Database-Layer.md` and the README's schema block — this repo has no `migrations/` folder, so these two places are the only record of what a fresh DB needs (this bit us with `enrich_attempts`)

### If you changed anything covered by the wiki
- [x] Updated the actual page under `wiki/` (not just the diagrams) — `Home.md` specifically is easy to forget since it doesn't get touched by most module-level changes, but it's the landing page
- [x] Searched the changed wiki pages for now-wrong terminology (e.g. a provider/library swap leaving stale references to the old one)

### Before merging
- [x] Ran the actual code path this PR touches, not just read it — an import succeeding isn't the same as the logic being correct (e.g. the `azalea.py` test-mode bug didn't crash, it just silently inserted the wrong data shape)
- [x] If you added a Mermaid diagram or edited one, validated the syntax actually parses (GitHub's renderer will silently show a parse error otherwise) — Mermaid sequence diagrams don't support `try`/`catch`; use `alt`/`else` instead