### PR TITLE
Wiki update

### DIFF
--- a/Refine/refine.py
+++ b/Refine/refine.py
@@ -17,8 +17,6 @@ from Refine.llm import OllamaProvider, LLMProvider, LLMParseError
 from Utils.models import Job
 import json
 
-from the import get_job_by_id
-
 # Fields we want  to fill. Enrichment is skipped entirely if all are present.
 ENRICH_FIELDS = ("description", "is_remote", "role_type", "pay_range", "tags")
 

--- a/docs/diagrams/azalea_class.md
+++ b/docs/diagrams/azalea_class.md
@@ -37,11 +37,13 @@ classDiagram
     }
 
     class RemoteOKHelper {
+        <<NOT IMPLEMENTED>>
         +fetch_jobs(position_type) List[Job]
     }
 
     class JobDatabase {
         +create() JobDatabase
+        +get_or_create_company(name) UUID
         +bulk_upsert(table, rows, conflict_column) list
     }
 
@@ -65,11 +67,11 @@ classDiagram
     Azalea --> JobStats : tracks via stats
     Azalea --> Simplify : helpers[SIMPLIFY]
     Azalea --> JSearch : helpers[JSEARCH]?
-    Azalea --> RemoteOKHelper : helpers[REMOTEOK]?
-    Azalea --> JobDatabase : bulk_upsert(fin_jobs)
+    Azalea ..> RemoteOKHelper : never instantiated — JobSource.REMOTEOK\nis a live enum value, but _init_helpers()\nhas no branch for it and there is no\nJobSource/remote.py file in this repo
+    Azalea --> JobDatabase : bulk_upsert(fin_jobs), get_or_create_company (test mode)
     Azalea --> enrich_unenriched_jobs : test mode only
     Azalea --> notify_discord : on error in main()
     Azalea --> JobSource : keys helpers dict
 
-    note for Azalea "self.jobs is now the single source of truth for\nBOTH modes — production sets it at Step 2\n(dedup), test mode builds it via Job.from_dict()\nin the JSON-load loop. Step 4 always converts\nself.jobs -> fin_jobs via to_dict_for_db() right\nbefore the DB call, so both modes get identical\nUUID/tags normalization. (Previously test mode\nbypassed this and inserted raw, unconverted JSON.)"
+    note for Azalea "self.jobs is the single source of truth for\nBOTH modes — production sets it at Step 2\n(dedup), test mode builds it via Job.from_dict()\nin the JSON-load loop. Step 4 always converts\nself.jobs -> fin_jobs via to_dict_for_db() right\nbefore the DB call, so both modes get identical\nUUID/tags normalization.\n\nTest mode now caps at the first 10 jobs from the\nJSON backup (was previously unbounded/20), skips\ndomains_to_ignore = {ziprecruiter, bebee, lensa}\n(grew from just {ziprecruiter}), and falls back to\ndb.get_or_create_company() when a job's JSON\n'company' field isn't a valid UUID string.\nTest mode's enrichment call also now runs with\nbatch_size=5, not 20."
 ```

--- a/docs/diagrams/azalea_seq.md
+++ b/docs/diagrams/azalea_seq.md
@@ -15,23 +15,21 @@ sequenceDiagram
         Az->>Az: log warning — JSearch disabled
     end
 
-    Az->>Cfg: REMOTEOK configured?
-    Note over Cfg: Config.REMOTEOK is a hardcoded URL string,\nnot a bool — always truthy, so this branch\nalways registers RemoteOK regardless of intent
-    alt configured
-        Az->>H: helpers[REMOTEOK] = RemoteOKHelper()
-    end
+    Note over Az,H: _init_helpers() has NO branch for JobSource.REMOTEOK at\nall — Config.REMOTEOK (a hardcoded URL string) is never even\nread here, and there is no RemoteOKHelper class or\nJobSource/remote.py file in the repo. helpers[REMOTEOK] is\nnever populated, so every "REMOTEOK in self.helpers" check\nelsewhere in Azalea is always False and that source is dead code.
 
 ```
 
 ```mermaid
 %% sequenceDiagram — fetch_from_source (route to correct helper)
-%% NOTE: position_type is forwarded to JSearch only. For SIMPLIFY and REMOTEOK
-%% the case _ branch calls helper.fetch_jobs() with no args, dropping position_type.
+%% NOTE: position_type is forwarded to JSearch only. For SIMPLIFY (the only other
+%% helper actually registered) the case _ branch calls helper.fetch_jobs() with no
+%% args, dropping position_type. REMOTEOK is included for completeness but never
+%% reaches this point in practice — see _init_helpers diagram above.
 sequenceDiagram
     participant FA as fetch_all_sources
     participant Az as fetch_from_source
     participant JS as JSearch.fetch_jobs
-    participant Other as Simplify / RemoteOK .fetch_jobs
+    participant Other as Simplify .fetch_jobs
 
     FA->>Az: await fetch_from_source(source, position_type, date_posted, **kwargs)
     Az->>Az: helper = helpers.get(source)
@@ -81,6 +79,7 @@ sequenceDiagram
     end
 
     alt REMOTEOK in helpers
+        Note over FA: never true in practice — REMOTEOK is\nnever added to self.helpers (see _init_helpers)
         FA->>FFS: fetch_from_source(REMOTEOK, position_type)
         FFS-->>FA: remoteok_jobs
         FA->>FA: all_jobs.extend(remoteok_jobs)
@@ -116,19 +115,19 @@ sequenceDiagram
     Note over Az: self.jobs is the single source of truth\nfrom here on, for both modes
 
     alt save_json=True
-        Az->>Az: Config.save_to_json([Job.to_dict(job) for job in unique_jobs])
-        Note over Az: to_dict() shape — company as str,\ntags not guaranteed dict. JSON-only, never DB-bound.
+        Az->>Az: Config.save_to_json([Job.to_dict(job) for job in unique_jobs\nif not any(domain in job.apply_url for domain in\n{ziprecruiter, bebee, lensa})])
+        Note over Az: to_dict() shape — company as str,\ntags not guaranteed dict. JSON-only, never DB-bound.\nDomain skip-list grew from just {ziprecruiter}.
     end
 
-    Az->>DB: JobDatabase.create()
-    Az->>Az: fin_jobs = [Job.to_dict_for_db(job) for job in self.jobs if job.title != "unknown"]
+    Note over Az,DB: JobDatabase.create() now happens at the very top\nof run(), before the test/production branch — not here.
+    Az->>Az: fin_jobs = [Job.to_dict_for_db(job) for job in self.jobs\nif job.title != "unknown" and job.apply_url\nand not any(domain in job.apply_url for domain in\n{ziprecruiter, bebee, lensa})]
     Note over Az: to_dict_for_db() shape — company as UUID,\ntags normalized to dict. THIS is what reaches Postgres.
 
     alt fin_jobs is empty
         Az-->>Entry: stats.to_dict() (early return, nothing to insert)
     end
 
-    Az->>DB: bulk_upsert(job_list, fin_jobs, conflict=[title,company,apply_url])
+    Az->>DB: bulk_upsert(job_list, fin_jobs, conflict=[company,location,title,apply_url])
     DB-->>Az: inserted list
     Az->>Az: stats.inserted = len(inserted)
 
@@ -152,33 +151,38 @@ sequenceDiagram
     participant Enrich as enrich_unenriched_jobs
 
     Dev->>Az: await run(test=True)
+    Az->>DB: JobDatabase.create()  (moved to top of run(), before the test/production branch)
 
-    Az->>FS: open + json.load()[:20]
-    Note over FS: raw dicts, in Job.to_dict() shape\n(company as str, tags shape not guaranteed)
+    Az->>FS: open + json.load()[:10]
+    Note over FS: raw dicts, in Job.to_dict() shape\n(company as str, tags shape not guaranteed).\nCap tightened from 20 to 10 jobs.
 
     alt FileNotFoundError or JSONDecodeError
         Az-->>Dev: stats.to_dict() (early return)
     end
 
     loop for each job_dict
-        Az->>Az: company_id = UUID(job_dict["company"])
+        Az->>Az: company_id = UUID(job_dict.get("company"))
+        alt company_id missing/invalid
+            Az->>DB: get_or_create_company(job_dict.get("company_name", "Unknown"))
+            DB-->>Az: company_id
+        end
         Az->>Az: job = Job.from_dict(job_dict, company=company_id)
         Az->>Az: self.jobs.append(job)
         Note over Az: self.jobs now holds proper Job objects,\nsame as production mode's unique_jobs
     end
 
-    Az->>DB: JobDatabase.create()
-    Az->>Az: fin_jobs = [Job.to_dict_for_db(job) for job in self.jobs if job.title != "unknown"]
-    Note over Az: SAME conversion step as production mode —\nthis is the fix. self.jobs is the shared source of truth.
+    Az->>Az: fin_jobs = [Job.to_dict_for_db(job) for job in self.jobs\nif job.title != "unknown" and job.apply_url\nand not any(domain in job.apply_url for domain in\n{ziprecruiter, bebee, lensa})]
+    Note over Az: SAME conversion + domain-skip logic as production\nmode. self.jobs is the shared source of truth.
 
     alt fin_jobs is empty
         Az-->>Dev: stats.to_dict() (early return)
     end
 
-    Az->>DB: bulk_upsert(job_list, fin_jobs, conflict=[title,company,apply_url])
+    Az->>DB: bulk_upsert(job_list, fin_jobs, conflict=[company,location,title,apply_url])
     DB-->>Az: inserted
 
-    Az->>Enrich: await enrich_unenriched_jobs(batch_size=20)
+    Az->>Enrich: await enrich_unenriched_jobs(batch_size=5)
+    Note over Enrich: batch_size tightened from 20 to 5
     Enrich-->>Az: enrich_stats
 
     Az->>Az: print_summary()

--- a/docs/diagrams/constants_class.md
+++ b/docs/diagrams/constants_class.md
@@ -17,12 +17,22 @@ classDiagram
         +DB_PASSWORD: str
         +DISCORD_WEBHOOK: str
         +DISCLAIMER_TEXT: str
+        -file_handler: FileHandler
         +logger: Logger
         +save_to_json(jobs, filepath)$
         +strip_html(text) str$
         +clean_ws(text) str$
         +is_missing(value) bool$
         +_norm_amount(s) float$
+    }
+
+    class LLMConstants {
+        <<constants>>
+        +_LLM_PROMPT: str
+        +_MAX_PROMPT_CHARS: int
+        +_VALID_ROLE_TYPES: set
+        +_ROLE_TYPE_KEYWORDS: list
+        +_TEXT_FIELD_LIMITS: dict
     }
 
     class PositionType {
@@ -142,4 +152,9 @@ classDiagram
     }
 
     Config --> FilePaths : save_to_json default path
+    Config --> LLMConstants : logging config shared by same module
+
+    note for Config "Logging now writes to logs/run.log via a\ndedicated file_handler (DEBUG level), in\naddition to the existing basicConfig setup.\n\nis_missing() now also treats the literal\nstrings '{}', '[]', 'null', and 'None' as\nmissing, on top of the prior '', 'Unknown',\n'other', 'unknown' — guards against LLM/DB\nround-trips that stringify empty containers."
+
+    note for LLMConstants "Prompt schema changed: the old flat\n'description' field is now 'summary'\n(2-4 sentence, own-words) plus a new\n'description_looks_valid' bool. job_expired\nis now specified to never return null (only\ntrue/false). _MAX_TAGS was removed —\ntags are no longer capped at 11 entries.\n_TEXT_FIELD_LIMITS now limits 'summary'\n(500 chars) instead of 'description'."
 ```

--- a/docs/diagrams/db_class.md
+++ b/docs/diagrams/db_class.md
@@ -12,6 +12,7 @@ classDiagram
         +create() JobDatabase$
         +select(table, columns, filters, raw_where, raw_params, order_by, limit) list[dict]
         +selectOne(table, columns, filters, order_by) dict
+        +get_or_create_company(name) UUID
         +upsert(table, data, conflict_column) dict
         +bulk_upsert(table, rows, conflict_column) list[dict]
         +update(table, data, filters) dict
@@ -19,12 +20,18 @@ classDiagram
         +call_function(fn, params, fetch_type) any
         +raw(sql, params) list[dict]
         -_build_conflict_clause(columns, conflict_column, table_name) tuple
+        -_serialize(v) any
+        -_json_default(o) str
     }
 
     class asyncpg_Pool {
         <<external: asyncpg>>
         +acquire() Connection
         +create_pool(...) Pool
+    }
+
+    class Vector {
+        <<external: pgvector>>
     }
 
     class Config {
@@ -38,4 +45,7 @@ classDiagram
 
     JobDatabase --> asyncpg_Pool : pool (connection pool)
     JobDatabase --> Config : reads DB credentials + logger
+    JobDatabase --> Vector : _serialize() passes pgvector Vector values through untouched
+
+    note for JobDatabase "_serialize(v) replaces the old inline\njson.dumps(v) check in upsert/bulk_upsert:\n- Vector → passed through as-is (asyncpg + pgvector\n  driver handles the wire format)\n- dict/list → json.dumps(v, default=_json_default)\n  (_json_default stringifies UUID and\n  datetime/date so embedding/tags/pay_range\n  payloads containing them don't raise\n  TypeError)\n- everything else → passed through unchanged\n\nget_or_create_company(name) is new — added for\nAzalea test mode, where a JSON-backed job may carry\na company name instead of a UUID. Looks up by\nlower(name), creates via upsert(conflict_column='name')\nif not found."
 ```

--- a/docs/diagrams/db_seq.md
+++ b/docs/diagrams/db_seq.md
@@ -12,6 +12,7 @@ sequenceDiagram
         DB->>DB: ssl.create_default_context()
         Note over DB: check_hostname=False, CERT_NONE
         DB->>DB: asyncpg.create_pool(host, port, db, user, password, ssl, min=2, max=10)
+        DB->>DB: register_vector() on each new connection (pgvector.asyncpg)
         DB->>DB: _instance = JobDatabase(_pool)
         DB-->>Caller: _instance
     end
@@ -19,10 +20,36 @@ sequenceDiagram
 ```
 
 ```mermaid
+%% sequenceDiagram — get_or_create_company (new)
+sequenceDiagram
+    participant Caller as Azalea (test mode)
+    participant DB as JobDatabase
+
+    Caller->>DB: get_or_create_company(name)
+    DB->>DB: selectOne(company, filters={lower(name): name.lower()})
+    alt row found
+        DB-->>Caller: row.id
+    else not found
+        DB->>DB: upsert(company, {name: name}, conflict_column="name")
+        DB-->>Caller: new row.id
+    end
+```
+
+```mermaid
 %% sequenceDiagram — _build_conflict_clause (ON CONFLICT strategy)
 sequenceDiagram
     participant Op as upsert / bulk_upsert
+    participant Ser as _serialize (per value)
     participant B as _build_conflict_clause
+
+    Op->>Ser: _serialize(v) for each column value
+    alt v is a pgvector Vector
+        Ser-->>Op: v unchanged
+    else v is dict/list
+        Ser-->>Op: json.dumps(v, default=_json_default)
+    else
+        Ser-->>Op: v unchanged
+    end
 
     Op->>B: _build_conflict_clause(columns, conflict_column, table_name)
 

--- a/docs/diagrams/embeddings_class.md
+++ b/docs/diagrams/embeddings_class.md
@@ -1,0 +1,47 @@
+```mermaid
+%% classDiagram — Tasks/embeddings.py (new module, no prior diagram)
+%% Standalone embedding + example-bank promotion pass, decoupled from enrich_unenriched_jobs().
+classDiagram
+    class embeddings_module {
+        <<Tasks/embeddings.py>>
+        +OLLAMA_HOST: str = "http://localhost:11434"
+        +embed(text) Vector
+        +too_similar_to_existing_example(db, embedding, threshold=0.95) bool
+        +passes_sanity_checks(job) bool
+        +maybe_promote_to_example_bank(job, db, embedding) str
+        -_build_embedding_text(job) str
+        +run_embedding_pass(batch_size=50) dict
+    }
+
+    class JobDatabase {
+        <<Service/db.py>>
+        +select(...) list~dict~
+        +update(...) dict
+        +upsert(...) dict
+        +raw(sql, params) list~dict~
+    }
+
+    class OllamaEmbeddingsAPI {
+        <<external: Ollama /api/embeddings, model=nomic-embed-text>>
+    }
+
+    class Vector {
+        <<external: pgvector>>
+    }
+
+    class notify_discord {
+        <<function, Utils/notify.py>>
+    }
+
+    class tqdm {
+        <<external: tqdm>>
+    }
+
+    embeddings_module --> JobDatabase : pulls enriched rows missing an embedding, writes embedding + enrichment_examples
+    embeddings_module --> OllamaEmbeddingsAPI : embed() via httpx POST
+    embeddings_module --> Vector : wraps raw embedding list
+    embeddings_module --> notify_discord : summary message on completion
+    embeddings_module --> tqdm : progress bar + background 1s refresh thread
+
+    note for embeddings_module "This is the RAG-example-bank logic that used to\nlive inline at the end of Refine/refine.py\n(too_similar_to_existing_example, passes_sanity_checks,\nmaybe_promote_to_example_bank) — moved here so a slow\nfirst-call Ollama embedding load never blocks the\nscrape/enrich cycle.\n\nmaybe_promote_to_example_bank() now takes the embedding\nas a parameter and reuses it (no re-embedding for the\npromotion check) — the old refine.py version recomputed it.\n\nNOT YET wired into any GitHub Actions workflow — no\ncron job in Automations.yaml calls this module. It must\nbe run manually (python -m Tasks.embeddings) until a\nschedule is added."
+```

--- a/docs/diagrams/embeddings_seq.md
+++ b/docs/diagrams/embeddings_seq.md
@@ -1,0 +1,44 @@
+```mermaid
+%% sequenceDiagram — run_embedding_pass() batch loop
+sequenceDiagram
+    participant Dev as Manual run (python -m Tasks.embeddings)
+    participant Run as run_embedding_pass
+    participant DB as JobDatabase
+    participant Ollama as Ollama /api/embeddings
+    participant Bar as tqdm progress bar
+    participant Discord as notify_discord
+
+    Dev->>Run: run_embedding_pass(batch_size=50)
+    Run->>DB: select(job_list, filters={enriched: True}, raw_where="enrich_attempts < 5", limit=50)
+    DB-->>Run: rows
+
+    alt no rows
+        Run-->>Dev: stats (nothing pending)
+    else rows to process
+        Run->>Bar: open tqdm(total=len(rows)); start 1s background refresh thread
+
+        loop each row
+            Run->>Run: _build_embedding_text(job) — title + description + tags(skills/technologies/requirements)
+            Run->>Ollama: POST /api/embeddings {model: nomic-embed-text, prompt: text}
+            Ollama-->>Run: embedding vector
+            Run->>DB: update(job_list, {embedding: Vector(embedding)}, filters={id})
+            Run->>Run: maybe_promote_to_example_bank(job, db, embedding)
+
+            alt enrich_attempts > 1
+                Run-->>Run: skip — too many failed enrich attempts
+            else fails passes_sanity_checks (role_type/pay_range/location/description length)
+                Run-->>Run: skip — sanity check failed
+            else too_similar_to_existing_example (cosine sim >= 0.95)
+                Run-->>Run: skip — near-duplicate of an existing example
+            else
+                Run->>DB: upsert(enrichment_examples, {source_job_id, raw_description,\nextracted_json, embedding, verified_by: "auto_clean_pass"},\nconflict_column=[source_job_id])
+                Run->>Run: stats.promoted += 1
+            end
+
+            Run->>Bar: update(1), set_postfix(promoted/embedded/errors/enrich_attempts)
+        end
+
+        Run->>Discord: notify_discord("Embedding pass complete — embedded: X, promoted: Y, errors: Z", file_path="embedded_jobs.txt")
+        Run-->>Dev: stats {attempted, embedded, promoted, errors}
+    end
+```

--- a/docs/diagrams/expired_class.md
+++ b/docs/diagrams/expired_class.md
@@ -1,0 +1,55 @@
+```mermaid
+%% classDiagram — Tasks/expired.py (new diagram — module previously had none)
+classDiagram
+    class ExpiryChecker {
+        +TIMEOUT: ClientTimeout = 8s
+        +DEAD_STATUS_CODES: set = {404, 410}
+        +GET_BYTE_LIMIT: int = 20000
+        +USER_AGENT: str
+        +DEFAULT_HTTP_CONCURRENCY: int = 10
+        +DEFAULT_HEAVY_CONCURRENCY: int = 2
+        +SPA_ONLY_DOMAINS: tuple
+        -http_semaphore: Semaphore
+        -heavy_semaphore: Semaphore
+        -pirate: Pirate
+        +use_llm: bool
+        +provider: LLMProvider
+        +llm_delay: float
+        +metrics: dict
+        +run(db) dict
+        -_is_spa_only_domain(url) bool
+        -_redirect_looks_expired(original_url, final_url) bool
+        -_visible_text(html) str$
+        -_cheap_check(session, url) Optional[bool]
+        -_deep_check(apply_url) Optional[bool]
+        -_check_one(session, job) tuple
+    }
+
+    class Pirate {
+        <<Service/Scrapper.py>>
+        +scrape_apply_url(url) ScrapeResult|dict|None
+        +classify_scraped_text(text) str
+    }
+
+    class LLMProvider {
+        <<abstract, Refine/llm.py>>
+        +extract(job, text) dict
+    }
+
+    class JobDatabase {
+        <<Service/db.py>>
+        +select(...) list~dict~
+        +raw(sql, params) list~dict~
+    }
+
+    class tqdm {
+        <<external: tqdm>>
+    }
+
+    ExpiryChecker --> Pirate : tiers 2/3 escalation
+    ExpiryChecker --> LLMProvider : tier 3 — expired-signal-only extraction
+    ExpiryChecker --> JobDatabase : run() pulls active jobs, flips status='expired' in bulk
+    ExpiryChecker --> tqdm : run() progress bar + background 1s refresh thread
+
+    note for ExpiryChecker "Three-tier escalation, cheapest first:\nTier 1 (_cheap_check): plain aiohttp GET, checks\n  DEAD_STATUS_CODES, redirect-looks-expired heuristics,\n  and (for non-SPA domains) visible-text signals.\n  SPA_ONLY_DOMAINS skip straight to tier 2 since a\n  plain GET only returns an empty JS shell for them.\nTier 2/3 (_deep_check): Pirate.scrape_apply_url() —\n  a dict result (structured OR the newer {blocked,\n  status_code} shape) is read via scraped.get('description')\n  either way; a ScrapeResult is classified via\n  classify_scraped_text(scraped.raw_text) then, if still\n  inconclusive, sent to the LLM for an expired-only signal.\n\nrun() now wraps asyncio.gather with asyncio.as_completed\ninside a tqdm progress bar (with a background thread\nticking pbar.refresh() every second) instead of a bare\nawait asyncio.gather(*tasks) — behavior is unchanged,\nonly progress visibility during long runs improved.\nDebug print() calls in _deep_check and _check_one have\nbeen removed in favor of the progress bar's postfix stats."
+```

--- a/docs/diagrams/expired_seq.md
+++ b/docs/diagrams/expired_seq.md
@@ -1,0 +1,84 @@
+```mermaid
+%% sequenceDiagram — ExpiryChecker.run() orchestration
+sequenceDiagram
+    participant Task as Tasks/expired.py (__main__) / weekly cron
+    participant Run as ExpiryChecker.run
+    participant DB as JobDatabase
+    participant Check as _check_one (per job)
+    participant Bar as tqdm progress bar
+
+    Task->>Run: run(db)
+    Run->>DB: select(job_list, filters={status: active})
+    DB-->>Run: jobs
+    Run->>Bar: open tqdm(total=len(jobs)); start 1s background refresh thread
+
+    par for each job (as_completed)
+        Run->>Check: _check_one(session, job)
+        Check-->>Run: (job_id, is_expired | None)
+        Run->>Bar: update(1), set_postfix(t1/t2/t3/blocked)
+    end
+
+    Run->>Run: collect newly_expired_ids where is_expired is True
+    alt any newly expired
+        Run->>DB: raw("UPDATE job_list SET status='expired' WHERE id = ANY($1)", [newly_expired_ids])
+    end
+
+    Run-->>Task: metrics {checked, newly_expired, failed, blocked, resolved_tier1/2/3}
+```
+
+```mermaid
+%% sequenceDiagram — _check_one() tiered escalation for a single job
+sequenceDiagram
+    participant Run as ExpiryChecker.run
+    participant C1 as _cheap_check (tier 1, http_semaphore)
+    participant C2 as _deep_check (tiers 2/3, heavy_semaphore)
+    participant P as Pirate
+    participant LLM as OllamaProvider.check_expired
+
+    Run->>C1: _cheap_check(session, apply_url)
+    C1->>C1: HEAD request → DEAD_STATUS_CODES / redirect-looks-expired?
+    alt confident from HEAD
+        C1-->>Run: True/False
+    else inconclusive, fall through to GET
+        C1->>C1: GET request, read first GET_BYTE_LIMIT bytes
+        alt SPA_ONLY_DOMAINS
+            C1-->>Run: None (escalate — raw HTML is an empty JS shell)
+        else classify_scraped_text(visible_text)
+            C1-->>Run: True (expired) / False (ok) / None (garbage → escalate)
+        end
+    end
+
+    alt tier 1 resolved (not None)
+        Note over Run: resolved_tier1 += 1
+    else tier 1 inconclusive
+        Run->>C2: _deep_check(apply_url)
+        C2->>P: scrape_apply_url(apply_url)
+        P-->>C2: ScrapeResult | dict (structured or blocked) | None
+
+        alt result is None
+            C2-->>Run: None (failed)
+        else dict with blocked=True
+            C2-->>Run: None
+            Note over C2: metrics.blocked += 1 — NOT treated as expired
+        else dict with job_expired True/False
+            C2-->>Run: True/False
+            Note over C2: metrics.resolved_tier2 += 1
+        else ScrapeResult
+            C2->>P: classify_scraped_text(scraped.raw_text)
+            alt "expired"
+                C2-->>Run: True (resolved_tier2 += 1)
+            else "garbage"
+                C2-->>Run: None
+            else "ok"
+                C2->>LLM: check_expired(scraped.raw_text)
+                alt model gives clear verdict
+                    LLM-->>C2: True/False
+                    C2-->>Run: True/False (resolved_tier3 += 1)
+                else no clear verdict
+                    LLM-->>C2: None
+                    C2-->>Run: None
+                end
+            end
+        end
+    end
+```

--- a/docs/diagrams/extractor_class.md
+++ b/docs/diagrams/extractor_class.md
@@ -1,5 +1,5 @@
 ```mermaid
-%% classDiagram — JobEnricher orchestrator + RegexConstants (replaces old function-based extractor)
+%% classDiagram — JobEnricher orchestrator + RegexConstants
 classDiagram
     class JobEnricher {
         +provider: LLMProvider
@@ -17,7 +17,7 @@ classDiagram
         -_missing_fields(job) list~str~
         -_run_regex(job) None
         -_run_scrape(job) None
-        -_handle_scraped_text(job, scraped) dict
+        -_handle_scraped_text(job, scraped: ScrapeResult) dict
         -_mark_expired() None
     }
 
@@ -42,8 +42,14 @@ classDiagram
 
     class Pirate {
         <<Service/Scrapper.py>>
-        +scrape_apply_url(url) str|dict|None
+        +scrape_apply_url(url) ScrapeResult|dict|None
         +classify_scraped_text(text) str
+    }
+
+    class ScrapeResult {
+        <<dataclass, Service/Scrapper.py>>
+        +raw_text: str
+        +trimmed_text: str
     }
 
     class LLMProvider {
@@ -53,12 +59,15 @@ classDiagram
 
     class Job {
         <<Utils/models.py>>
+        +description: str
+        +summary: Optional[str]
     }
 
     JobEnricher --> RegexConstants : stage 1
     JobEnricher --> Pirate : stage 2 (scrape)
+    JobEnricher --> ScrapeResult : consumes .raw_text / .trimmed_text
     JobEnricher --> LLMProvider : stage 3 (LLM)
     JobEnricher --> Job : mutates in place
 
-    note for JobEnricher "meta is built once in __init__ and\nNOT reset between calls — callers\nmust create a fresh instance per job\n(see Refine/refine.py)"
+    note for JobEnricher "meta is built once in __init__ and\nNOT reset between calls — callers\nmust create a fresh instance per job\n(see Refine/refine.py).\n\ndescription is now filled directly from\nscraped.trimmed_text (capped 50000 chars),\nnot by the LLM. The LLM instead returns a\nseparate 'summary' field (2-4 sentences) and\na 'description_looks_valid' bool used only\nfor a warning, not to block the fill.\n\n_run_scrape() branches on isinstance(scraped, dict)\nfor BOTH the authoritative JobPosting dict and the\nnewer {blocked: True, status_code} dict from Pirate —\nit does not currently distinguish them, so a blocked\nscrape is treated as (empty) structured data rather\nthan retried or logged as blocked."
 ```

--- a/docs/diagrams/extractor_seq.md
+++ b/docs/diagrams/extractor_seq.md
@@ -21,42 +21,56 @@ sequenceDiagram
             JE->>JE: _run_scrape(job)
             JE->>P: scrape_apply_url(apply_url)
 
-            alt schema.org JobPosting found
-                P-->>JE: dict (structured, authoritative)
-                JE->>JE: _apply_structured_data(job, structured)
-                Note over JE: OVERWRITES existing fields
-                alt still missing
-                    JE->>LLM: extract(job, job.description)
-                    LLM-->>JE: sanitized dict
-                    JE->>JE: _apply_to_job(job, extracted)
+            alt any dict returned (structured JobPosting OR blocked)
+                P-->>JE: dict
+                alt dict.job_expired is true
+                    JE->>JE: _mark_expired(job)
+                else
+                    JE->>JE: _apply_structured_data(job, structured)
+                    Note over JE: OVERWRITES existing fields.\nNote: a {blocked, status_code} dict flows\nthrough this same branch — treated as an\n(empty) structured payload rather than as\na blocked-request signal.
+                    alt still missing
+                        JE->>LLM: extract(job, structured.get("description"))
+                        LLM-->>JE: sanitized dict {job_expired, description_looks_valid, summary, ...}
+                        alt job_expired = true
+                            JE->>JE: _mark_expired(job)
+                        else
+                            JE->>JE: pop summary → job.summary (if missing)
+                            JE->>JE: pop description_looks_valid → warning only if false
+                            JE->>JE: _apply_to_job(job, remaining extracted)
+                        end
+                    end
                 end
-            else rendered text or None
-                P-->>JE: str | None
-                alt text is None
+            else ScrapeResult or None
+                P-->>JE: ScrapeResult(raw_text, trimmed_text) | None
+                alt result is None
                     JE-->>Caller: meta (scrape failed)
-                else text returned
-                    JE->>P: classify_scraped_text(text)
+                else ScrapeResult returned
+                    JE->>P: classify_scraped_text(scraped.raw_text)
                     P-->>JE: "expired" | "garbage" | "ok"
                     alt expired
                         JE->>JE: _mark_expired(job)
                     else garbage
                         Note over JE: no further action
                     else ok
-                        JE->>RC: regex_pay/regex_remote/regex_role_type(text)
+                        JE->>JE: snapshot was_missing_before_fill = _missing_fields(job)
+                        JE->>RC: regex_pay/regex_remote/regex_role_type(scraped.raw_text)
                         RC-->>JE: extracted fields
-                        alt still missing
-                            JE->>LLM: extract(job, text)
-                            LLM-->>JE: sanitized dict
+                        JE->>JE: job.description = scraped.trimmed_text[:50000] (if missing)
+                        alt "description" was in was_missing_before_fill AND use_llm
+                            JE->>LLM: extract(job, scraped.trimmed_text)
+                            LLM-->>JE: sanitized dict {job_expired, description_looks_valid, summary, ...}
                             alt job_expired = true
                                 JE->>JE: _mark_expired(job)
                             else
-                                JE->>JE: _apply_to_job(job, extracted)
+                                JE->>JE: pop summary → job.summary (if missing)
+                                JE->>JE: pop description_looks_valid → warning only if false
+                                JE->>JE: _apply_to_job(job, remaining extracted)
                             end
                         end
                     end
                 end
             end
         end
-        JE-->>Caller: meta {stages_run, fields_filled}
+        JE-->>Caller: meta {stages_run, fields_filled, warnings?}
     end
 ```

--- a/docs/diagrams/main_api_seq.md
+++ b/docs/diagrams/main_api_seq.md
@@ -28,11 +28,12 @@ sequenceDiagram
     participant PG as PostgreSQL
 
     Client->>App: GET /jobs?limit=N
-    App->>DB: db.select("job_list", order_by="created_at DESC", limit=N)
-    DB->>PG: SELECT * FROM job_list ORDER BY created_at DESC LIMIT N
+    App->>DB: db.select("job_list", filters={enriched: True, status: "active"}, order_by="created_at ASC", limit=N)
+    DB->>PG: SELECT * FROM job_list WHERE enriched=true AND status='active' ORDER BY created_at ASC LIMIT N
     PG-->>DB: rows
     DB-->>App: list[dict]
     App-->>Client: {success: true, params: {limit}, jobs: [...]}
+    Note over App: order_by is ASC (oldest first), not DESC —\nworth confirming this is intentional for a "recent jobs" feed.
 ```
 
 ```mermaid
@@ -44,8 +45,8 @@ sequenceDiagram
     participant PG as PostgreSQL
 
     Client->>App: GET /company/google?limit=N
-    App->>DB: db.select("job_list", raw_where="company = (SELECT id FROM company WHERE name = $1)", raw_params=["google"])
-    DB->>PG: SELECT * FROM job_list WHERE company = (subquery) ORDER BY created_at DESC LIMIT N
+    App->>DB: db.select("job_list", raw_where="company = (SELECT id FROM company WHERE name = $1) AND enriched=true AND status='active'", raw_params=["google"], order_by="created_at ASC")
+    DB->>PG: SELECT * FROM job_list WHERE company = (subquery) AND enriched=true AND status='active' ORDER BY created_at ASC LIMIT N
     PG-->>DB: rows
     DB-->>App: list[dict]
     App-->>Client: {success: true, params: {company_name, limit}, jobs: [...]}
@@ -61,11 +62,12 @@ sequenceDiagram
 
     Client->>App: GET /search/python
     App->>App: keyword.lower() → "python"
-    App->>DB: db.select("job_list", raw_where="lower(title) LIKE $1", raw_params=["%python%"])
-    DB->>PG: SELECT * FROM job_list WHERE lower(title) LIKE '%python%' ORDER BY created_at DESC
+    App->>DB: db.select("job_list", raw_where="lower(title) LIKE $1 AND enriched=true AND status='active'", raw_params=["%python%"], order_by="created_at ASC")
+    DB->>PG: SELECT * FROM job_list WHERE lower(title) LIKE '%python%' AND enriched=true AND status='active' ORDER BY created_at ASC
     PG-->>DB: rows
     DB-->>App: list[dict]
     App-->>Client: {success: true, params: {keyword}, jobs: [...]}
+    Note over App: No limit param on this route — a common keyword\ncould return the entire active, enriched table.
 ```
 
 ```mermaid
@@ -80,8 +82,8 @@ sequenceDiagram
     participant PG as PostgreSQL
 
     Client->>App: GET /sponsor
-    App->>DB: db.select("job_list", raw_where="tags->>'sponsorship' = 'true'")
-    DB->>PG: SELECT * FROM job_list WHERE tags->>'sponsorship' = 'true' ORDER BY created_at DESC
+    App->>DB: db.select("job_list", raw_where="tags->>'sponsorship' = 'true' AND enriched=true AND status='active'", order_by="created_at DESC")
+    DB->>PG: SELECT * FROM job_list WHERE tags->>'sponsorship' = 'true' AND enriched=true AND status='active' ORDER BY created_at DESC
     PG-->>DB: rows (currently always empty — no enricher sets this key)
     DB-->>App: []
     App-->>Client: {success: true, params: {sponsorship: "likely sponsorship"}, jobs: []}

--- a/docs/diagrams/models_class.md
+++ b/docs/diagrams/models_class.md
@@ -13,6 +13,7 @@ classDiagram
         +pay_range: Optional[list]
         +source: str
         +tags: dict[str, str]
+        +summary: Optional[str]
         +is_valid() bool
         +get_salary_info() str
         +from_dict(job, company) Job$
@@ -78,6 +79,6 @@ classDiagram
     JobStats --> PositionType : position_type field
     JobStats --> JobSource : increment_source routing
     JobStats --> StatsKeys : to_dict keys
-    Job "hash/eq on" ..> Job : title + company + location + apply_url
+    Job "hash/eq on" ..> Job : title + company + location + apply_url + summary
 
 ```

--- a/docs/diagrams/refine_class.md
+++ b/docs/diagrams/refine_class.md
@@ -27,9 +27,18 @@ classDiagram
         <<Exception, Refine/llm.py>>
     }
 
+    class tqdm {
+        <<external: tqdm>>
+        +update(1)
+        +set_postfix(dict)
+    }
+
     refine_module --> JobDatabase : pull unenriched batch, persist results
     refine_module --> JobEnricher : "new instance created PER JOB\n(meta dict isn't reset between calls)"
+    refine_module --> tqdm : progress bar + background 1s refresh thread
     refine_module ..> LLMParseError : catches, increments enrich_attempts,\ncaps retries at MAX_ENRICH_ATTEMPTS
 
-    note for refine_module "Bug fixed: previously imported a\ntop-level enrich_job() function that\nno longer existed after the JobEnricher\nrefactor — broke this module's import\nentirely. Now imports JobEnricher class\nand instantiates it inside the loop."
+    note for refine_module "BROKEN IMPORT: the module currently has\n'from the import get_job_by_id' at module\nscope. There is no 'the' module anywhere in\nthis repo and get_job_by_id is never called —\nthis raises ModuleNotFoundError the instant\nrefine.py (or anything that imports it, e.g.\nazalea.py / Tasks/enrich.py) is loaded. This\nis a regression versus the previously-fixed\nimport bug documented in Roadmap — needs a\nfollow-up fix (delete the line)."
+
+    note for refine_module "RAG example-bank promotion (too_similar_to_existing_example,\npasses_sanity_checks, maybe_promote_to_example_bank) has\nmoved OUT of this module entirely — it now lives in the new\nTasks/embeddings.py as a standalone pass, decoupled from\nenrichment so a slow first Ollama embedding call never\nblocks enrichment throughput."
 ```

--- a/docs/diagrams/refine_seq.md
+++ b/docs/diagrams/refine_seq.md
@@ -5,10 +5,12 @@ sequenceDiagram
     participant Ref as enrich_unenriched_jobs
     participant DB as JobDatabase
     participant JE as JobEnricher (fresh per job)
+    participant Bar as tqdm progress bar
 
     Task->>Ref: enrich_unenriched_jobs(batch_size=20)
-    Ref->>DB: select(job_list, filters={enriched: False}, limit=20, order_by=created_at ASC)
+    Ref->>DB: select(job_list, filters={enriched: False, status: active}, limit=20, order_by=created_at DESC)
     DB-->>Ref: rows
+    Ref->>Bar: open tqdm(total=len(rows)); start 1s background refresh thread
 
     loop each row
         Ref->>Ref: _needs_enrichment(row)
@@ -16,14 +18,14 @@ sequenceDiagram
             Ref->>DB: update(enriched=True)
             Note over Ref: stats.skipped += 1
         else needs enrichment
-            Ref->>Ref: _row_to_job(row)
+            Ref->>Ref: _row_to_job(row)  — normalizes tags if stored as a JSON string
             Ref->>JE: new JobEnricher(provider, use_llm)
             Ref->>JE: enrich_job(job)
 
             alt success
                 JE-->>Ref: meta
                 Ref->>DB: upsert(job_list, payload with enriched=True)
-                Note over Ref: stats.enriched += 1
+                Note over Ref: stats.enriched += 1, row appended to ENRICHED
             else LLMParseError raised
                 JE-->>Ref: raises LLMParseError
                 Ref->>Ref: attempts = row.enrich_attempts + 1
@@ -39,8 +41,11 @@ sequenceDiagram
                 Note over Ref: stats.errors += 1, row left enriched=False
             end
         end
-        Ref->>Ref: sleep(llm_delay) if use_llm
+        Ref->>Bar: update(1), set_postfix(enriched/skipped/errors/gave_up)
+        Ref->>Ref: sleep(llm_delay) if use_llm and not last row
     end
+
+    Note over Ref: Unlike the previous version, this loop no longer\ncalls maybe_promote_to_example_bank() at the end —\nthat pass now runs independently via Tasks/embeddings.py.
 
     Ref-->>Task: {attempted, enriched, skipped, errors, gave_up}
 ```

--- a/docs/diagrams/sanitate_class.md
+++ b/docs/diagrams/sanitate_class.md
@@ -1,5 +1,5 @@
 ```mermaid
-%% classDiagram — JobDataSanitizer (Utils/sanitate.py) - new module, no prior diagram
+%% classDiagram — JobDataSanitizer (Utils/sanitate.py)
 classDiagram
     class JobDataSanitizer {
         +sanitize(data: dict) dict
@@ -9,6 +9,7 @@ classDiagram
         -_normalise_is_remote(data) dict
         -_normalise_job_expired(data) dict
         -_normalise_tags(data) dict
+        -_normalise_description_valid(data) dict
         -_normalise_text_fields(data) dict
         -_missing_fields(job) list~str~
     }
@@ -19,7 +20,6 @@ classDiagram
         +_MAX_PROMPT_CHARS: int = 10000
         +_VALID_ROLE_TYPES: set
         +_ROLE_TYPE_KEYWORDS: list
-        +_MAX_TAGS: int
         +_TEXT_FIELD_LIMITS: dict
     }
 
@@ -30,5 +30,5 @@ classDiagram
     JobDataSanitizer --> LLMConstants : prompt template + validation rules
     JobDataSanitizer --> Job : reads known fields for prompt building
 
-    note for JobDataSanitizer "sanitize() runs the full chain in order:\npay → role_type → is_remote → job_expired\n→ tags → text_fields. Each step is a no-op\nif its key isn't present in the input dict,\nso partial LLM output degrades gracefully."
+    note for JobDataSanitizer "sanitize() runs the full chain in order:\npay → role_type → is_remote → job_expired\n→ tags → text_fields → description_valid.\nEach step is a no-op if its key isn't present\nin the input dict, so partial LLM output\ndegrades gracefully.\n\n_normalise_tags() no longer caps entries at\n_MAX_TAGS or truncates each value to 100 chars\n— that cap was removed from LLMConstants along\nwith the flat-tags shape (tags now hold richer\nlist-valued entries like skills/technologies).\n\n_normalise_description_valid() is new: coerces\ndescription_looks_valid into a strict bool,\ndefaulting to True (fail-open) if missing,\nunparseable, or not already a bool."
 ```

--- a/docs/diagrams/scrapper_class.md
+++ b/docs/diagrams/scrapper_class.md
@@ -1,18 +1,31 @@
 ```mermaid
-%% classDiagram — Pirate (Service/Scrapper.py) - new module, no prior diagram
+%% classDiagram — Pirate (Service/Scrapper.py)
 classDiagram
+    class ScrapeResult {
+        <<dataclass>>
+        +raw_text: str
+        +trimmed_text: str
+    }
+
     class Pirate {
         -_COOKIE_NOTICE_RE: Pattern
+        -_COOKIE_BANNER_TAIL_RE: Pattern
+        -_COOKIE_TAIL_SIGNALS: list~str~
+        -_DESC_START_MARKERS: list~str~
+        -_DESC_END_MARKERS: list~str~
         -_EXPIRED_SIGNALS: list~str~
         -_GARBAGE_SIGNALS: list~str~
         -_SITE_EXPIRED_URL_PATTERNS: dict
+        -BLOCKED_STATUS_CODES: set 
         -_HEADERS: dict
-        +scrape_apply_url(url) str | dict | None
+        +scrape_apply_url(url) ScrapeResult | dict | None
         +classify_scraped_text(text) str
         -_is_known_expired_redirect(final_url) bool
         -_extract_jobposting_jsonld(html) dict
-        -_strip_cookie_boilerplate(text) str
         -_jobposting_to_fields(posting) dict
+        -_strip_cookie_boilerplate(text) str
+        -_trim_trailing_cookie_banner(text, window) str
+        -_trim_to_description(text) str
     }
 
     class PlaywrightBrowser {
@@ -29,8 +42,9 @@ classDiagram
         +get(url) Response
     }
 
+    Pirate --> ScrapeResult : returned on successful rendered-text scrape
     Pirate --> PlaywrightBrowser : primary scrape path
     Pirate --> RequestsFallback : fallback if Playwright unavailable/fails
 
-    note for Pirate "scrape_apply_url() return type carries meaning:\n- dict = schema.org JobPosting JSON-LD found\n  (authoritative, caller should OVERWRITE)\n- str = rendered text (caller should merge via\n  regex/LLM, never overwrite)\n- None = scrape failed or known-expired redirect"
+    note for Pirate "scrape_apply_url() return type carries meaning:\n- dict with job_expired/description/etc = schema.org\n  JobPosting JSON-LD found (authoritative, caller\n  should OVERWRITE)\n- dict {blocked: True, status_code} = site actively\n  refused the request (403/429) — NOT evidence the\n  job is expired, just that this attempt was blocked.\n  extractor.py's _run_scrape() currently does not\n  check for this shape before treating any dict as\n  structured JobPosting data — see Roadmap.\n- ScrapeResult(raw_text, trimmed_text) = rendered text.\n  raw_text is cookie-stripped full text, used for regex\n  and classify_scraped_text(). trimmed_text is narrowed\n  to the Responsibilities→Qualifications window via\n  _trim_to_description(), used for job.description and\n  as the LLM prompt body.\n- None = scrape failed or known-expired redirect"
 ```

--- a/docs/diagrams/scrapper_seq.md
+++ b/docs/diagrams/scrapper_seq.md
@@ -1,43 +1,53 @@
 ```mermaid
 %% sequenceDiagram — Pirate.scrape_apply_url() full decision path
 sequenceDiagram
-    participant Caller as JobEnricher
+    participant Caller as JobEnricher / ExpiryChecker
     participant P as Pirate
     participant PW as Playwright
     participant Req as requests (fallback)
 
     Caller->>P: scrape_apply_url(url)
 
-    P->>PW: launch chromium, goto(url)
+    P->>PW: launch chromium, goto(url, wait_until="domcontentloaded")
     alt Playwright available and succeeds
-        PW-->>P: page loaded
+        PW-->>P: response
 
-        opt url contains myworkdayjobs.com
-            P->>PW: wait_for_selector(jobPostingDescription)
-            Note over P: logs warning if selector never appears
-        end
+        alt response.status in BLOCKED_STATUS_CODES (403/429)
+            P-->>Caller: {"blocked": True, "status_code": ...}
+        else not blocked
+            P->>PW: wait_for_load_state("networkidle", timeout=8000) — best effort
 
-        P->>P: _is_known_expired_redirect(page.url)
-        alt known expired redirect
-            P-->>Caller: None
-        else not expired
-            P->>PW: content() → html
-            P->>P: _extract_jobposting_jsonld(html)
+            opt url contains myworkdayjobs.com
+                P->>PW: wait_for_selector(jobPostingDescription)
+                Note over P: logs warning if selector never appears
+            end
 
-            alt JobPosting JSON-LD found
-                P->>P: _jobposting_to_fields(posting)
-                P-->>Caller: dict (structured, authoritative)
-            else no structured data
-                P->>PW: evaluate(remove nav/footer/header/script/style)
-                P->>PW: evaluate(remove cookie/consent elements)
-                P->>PW: check all frames, keep longest inner_text
-                P->>P: _strip_cookie_boilerplate(text)
-                P-->>Caller: str (rendered text, capped 10000 chars)
+            P->>P: _is_known_expired_redirect(page.url)
+            alt known expired redirect
+                P-->>Caller: None
+            else not expired
+                P->>PW: content() → html
+                P->>P: _extract_jobposting_jsonld(html)
+
+                alt JobPosting JSON-LD found
+                    P->>P: _jobposting_to_fields(posting)
+                    P-->>Caller: dict (structured, authoritative)
+                else no structured data
+                    P->>PW: evaluate(remove nav/footer/header/script/style)
+                    P->>PW: evaluate(remove cookie/consent elements)
+                    P->>PW: check all frames, keep longest inner_text
+                    P->>P: _strip_cookie_boilerplate(text) → full_text
+                    P->>P: _trim_to_description(full_text) → trimmed
+                    P-->>Caller: ScrapeResult(raw_text=full_text, trimmed_text=trimmed)
+                end
             end
         end
     else Playwright import fails or errors
         P->>Req: requests.get(url, headers)
-        alt known expired redirect
+        alt status in BLOCKED_STATUS_CODES
+            Req-->>P: response
+            P-->>Caller: {"blocked": True, "status_code": ...}
+        else known expired redirect
             Req-->>P: response
             P-->>Caller: None
         else
@@ -46,8 +56,9 @@ sequenceDiagram
             alt found
                 P-->>Caller: dict (structured)
             else
-                P->>P: strip nav/footer/script/style tags, strip cookie boilerplate
-                P-->>Caller: str (static-only text, capped 10000 chars)
+                P->>P: strip nav/footer/script/style tags
+                P->>P: _strip_cookie_boilerplate + _trim_to_description
+                P-->>Caller: ScrapeResult(raw_text, trimmed_text)
             end
         end
     end
@@ -56,10 +67,10 @@ sequenceDiagram
 ```mermaid
 %% sequenceDiagram — Pirate.classify_scraped_text()
 sequenceDiagram
-    participant Caller as JobEnricher
+    participant Caller as JobEnricher / ExpiryChecker
     participant P as Pirate
 
-    Caller->>P: classify_scraped_text(text)
+    Caller->>P: classify_scraped_text(scraped.raw_text)
     P->>P: lowercase + normalize smart quotes
 
     alt matches any _EXPIRED_SIGNALS phrase
@@ -71,4 +82,6 @@ sequenceDiagram
     else
         P-->>Caller: "ok"
     end
+
+    Note over Caller,P: Callers now pass scraped.raw_text explicitly since\nscrape_apply_url() returns a ScrapeResult, not a bare str.
 ```

--- a/wiki/API-Reference.md
+++ b/wiki/API-Reference.md
@@ -8,25 +8,29 @@ Standard response shape:
 { "success": true, "params": { ... }, "jobs": [ ... ] }
 ```
 
+All job-listing routes below implicitly filter to `enriched = true AND status = 'active'` — unenriched and expired rows never surface through the API.
+
 ## `GET /`
 
 Metadata + endpoint list. No params.
 
 ## `GET /jobs?limit=N`
 
-All jobs, newest first (`created_at DESC`). `limit` optional.
+All active, enriched jobs, ordered `created_at ASC` (oldest first). `limit` optional.
+
+> Worth double-checking this is intentional — `ASC` on a "browse jobs" endpoint means the oldest matching rows page in first, which is an easy off-by-one direction to get wrong versus a "recent jobs" feed. `/sponsor` below uses `DESC` for the same kind of query, so the two routes are inconsistent with each other if that wasn't deliberate.
 
 ## `GET /company/{company_name}?limit=N`
 
-Jobs for one company. `company_name` must be **lowercase** — matched against `company.name` via a subquery (`company = (SELECT id FROM company WHERE name = $1)`), not a join.
+Jobs for one company. `company_name` must be **lowercase** — matched against `company.name` via a subquery (`company = (SELECT id FROM company WHERE name = $1)`), not a join. Also ordered `created_at ASC`.
 
 ## `GET /search/{keyword}`
 
-Case-insensitive `LIKE` match on `title` only (not description). No `limit` param currently exposed on this route.
+Case-insensitive `LIKE` match on `title` only (not `description` or `summary`). Ordered `created_at ASC`. No `limit` param currently exposed on this route — a common keyword could return the entire active, enriched table.
 
 ## `GET /sponsor`
 
-Jobs where `tags->>'sponsorship' = 'true'`. This is an LLM-assigned tag (see `_LLM_PROMPT` in [[Enrichment-Pipeline]]) — not independently verified, hence the disclaimer text in `Config.DISCLAIMER_TEXT`.
+Jobs where `tags->>'sponsorship' = 'true'`, ordered `created_at DESC`. This is meant to be an LLM-assigned tag (see `_LLM_PROMPT` in [[Enrichment-Pipeline]]) — but the current tags schema doesn't actually include a `sponsorship` key anywhere (it produces `experience_years`, `requirements`, `preferred`, `skills`, `technologies`, `certifications`). As written, this route will always return an empty list until either the prompt schema adds a sponsorship signal or this route is pointed at a different field. Not independently verified either way, hence the disclaimer text in `Config.DISCLAIMER_TEXT`.
 
 ## Error responses
 
@@ -41,3 +45,5 @@ Jobs where `tags->>'sponsorship' = 'true'`. This is an LLM-assigned tag (see `_L
 - No pagination anywhere (`limit` only, no offset/cursor)
 - No auth — fully open CORS (`allow_origins=["*"]`)
 - `company_name` lowercase requirement isn't documented anywhere except this wiki page and the (old) README
+- `/jobs` and `/company` order `ASC`, `/sponsor` orders `DESC` — check this is intentional before relying on either
+- `/sponsor` is currently dead — no enrichment path sets `tags->>'sponsorship'`

--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -6,54 +6,64 @@
 flowchart TD
     A[Simplify README] --> D[Azalea.fetch_all_sources]
     B[JSearch API] --> D
-    C[RemoteOK API] --> D
-    D --> E["Dedup: set() via Job.__hash__/__eq__"]
+    D --> E["Dedup: set() via Job.__hash__/__eq__ (now incl. summary)"]
     E --> F["Job.is_valid() filter"]
-    F --> G[Optional: save_to_json backup]
+    F --> G[Optional: save_to_json backup, skips ziprecruiter/bebee/lensa domains]
     F --> H["JobDatabase.bulk_upsert(job_list)"]
     H --> I["ON CONFLICT DO UPDATE + COALESCE"]
-    I --> J[enrich_unenriched_jobs]
+    I --> J["enrich_unenriched_jobs (Tasks/enrich.py, once/day)"]
     J --> K["JobEnricher: regex stage"]
-    K --> L["Pirate.scrape_apply_url: structured JobPosting or rendered text"]
-    L --> M["OllamaProvider LLM stage (deepseek-r1:8b)"]
+    K --> L["Pirate.scrape_apply_url: ScrapeResult(raw_text, trimmed_text) or structured/blocked dict"]
+    L --> M["OllamaProvider LLM stage (deepseek-r1:8b) → summary + description_looks_valid + job_expired"]
     M --> N["mark enriched = true"]
-    N --> O["FastAPI read-only routes (main.py)"]
+    N --> O["run_embedding_pass (Tasks/embeddings.py, standalone, not yet scheduled)"]
+    N --> P["FastAPI read-only routes (main.py)"]
+    N --> Q["ExpiryChecker weekly pass (Tasks/expired.py)"]
+    Q --> H
 ```
+
+Note: `RemoteOK` is a live `JobSource` enum value and appears in gating checks throughout `Azalea`, but `_init_helpers()` never actually registers a helper for it — there is no `JobSource/remote.py` file in the repo. It's effectively dead code today, not a wired-up third source. See [[Roadmap]].
 
 ## Orchestrator: `Service/azalea.py`
 
-`Azalea` is the controller. `_init_helpers()` builds a `helpers` dict keyed by `JobSource` enum — Simplify is always on, JSearch only if its API key is configured, RemoteOK via a `Config.REMOTEOK` check that's actually a hardcoded URL string (always truthy, so RemoteOK always registers regardless of any intended toggle). `run()` has two modes, both converging on the same DB-insert step:
+`Azalea` is the controller. `_init_helpers()` builds a `helpers` dict keyed by `JobSource` enum — Simplify is always on, JSearch only if its API key is configured. `run()` has two modes, both converging on the same DB-insert step:
 
 **Production mode (`test=False`, the normal path via `Tasks/scrape.py`):**
 
 1. `fetch_all_sources()` — concurrently pulls from every configured source, tags per-source counts on `self.stats` (`JobStats`)
-2. Dedup via Python `set()` — relies on `Job.__hash__`/`__eq__` keyed on `(title, company, location, apply_url)` — then filters through `Job.is_valid()`
+2. Dedup via Python `set()` — relies on `Job.__hash__`/`__eq__`, now keyed on `(title, company, location, apply_url, summary)` (the `summary` field was added to the hash/eq tuple — see [[Database-Layer]])
 3. `self.jobs = unique_jobs` — this is the key line: `self.jobs` becomes the single source of truth for the rest of `run()`, shared by both modes
-4. Optional JSON backup via `Config.save_to_json([Job.to_dict(job) for job in unique_jobs])` — note this uses `to_dict()`, not `to_dict_for_db()` (see below)
-5. `fin_jobs = [Job.to_dict_for_db(job) for job in self.jobs if job.title != "unknown"]`, then `bulk_upsert` into `job_list` with `ON CONFLICT (title, company, apply_url) DO UPDATE` — see [[Database-Layer]] for the COALESCE trick
+4. Optional JSON backup via `Config.save_to_json([Job.to_dict(job) for job in unique_jobs if not any(domain in job.apply_url for domain in domains_to_ignore)])` — the domain skip-list grew from just `{"ziprecruiter"}` to `{"ziprecruiter", "bebee", "lensa"}`
+5. `fin_jobs = [Job.to_dict_for_db(job) for job in self.jobs if job.title != "unknown" and job.apply_url and not any(domain in job.apply_url for domain in domains_to_ignore)]`, then `bulk_upsert` into `job_list` with `ON CONFLICT (company, location, title, apply_url) DO UPDATE` — see [[Database-Layer]] for the COALESCE trick
 
 **Test mode (`test=True`, used for iterating on enrichment logic without re-scraping):**
 
-1. Skips fetch/dedup entirely, loads from the local `resources/scraped_jobs.json` backup instead (max 20 jobs)
-2. Reconstructs each raw JSON dict back into a proper `Job` object via `Job.from_dict(job_dict, company=UUID(...))`, appending to `self.jobs`
-3. From here it converges with production mode: same `fin_jobs = [Job.to_dict_for_db(job) for job in self.jobs ...]` conversion, same `bulk_upsert` call
-4. Additionally runs `enrich_unenriched_jobs(batch_size=20)` right after inserting — production mode skips this
+1. Skips fetch/dedup entirely, loads from the local `resources/scraped_jobs.json` backup instead — now capped at the **first 10** jobs (was previously the full file / 20 in older docs)
+2. Reconstructs each raw JSON dict back into a proper `Job` object via `Job.from_dict(job_dict, company=company_id)`. If the JSON's `company` field isn't a valid UUID, it now falls back to `db.get_or_create_company(job_dict.get("company_name", "Unknown"))` instead of raising — a new `JobDatabase` method (see [[Database-Layer]])
+3. From here it converges with production mode: same `fin_jobs` conversion, same `bulk_upsert` call
+4. Additionally runs `enrich_unenriched_jobs(batch_size=5)` right after inserting — tightened down from `batch_size=20` — production mode skips this entirely
 
-> ⚠️ **Bug found and fixed:** test mode used to build the DB-bound list directly from the raw JSON file, skipping the `to_dict_for_db()` conversion that normalizes `company` into a real UUID object and coerces `tags` into a proper dict. The reconstructed `Job` objects were built correctly in a loop but never actually used for the DB insert — the raw, unconverted JSON went in instead. Fixed by making `self.jobs` the shared source of truth for both modes, with the `to_dict_for_db()` conversion happening once, right before the DB call, regardless of which mode populated `self.jobs`.
+`JobDatabase.create()` is now called once at the very top of `run()`, before the test/production branch splits, rather than partway through Step 4 — needed so test mode's `get_or_create_company()` fallback has a `db` handle available during the JSON-load loop.
 
 ## Why enrichment is decoupled from scraping
 
-Scraping runs 5x/day (cron in `scrape.yaml`); enrichment only runs on the `0 5 * * *` slot (or manual dispatch). This keeps local Ollama enrichment time bounded and means a scrape failure doesn't block enrichment of already-inserted rows, and vice versa.
+Scraping runs 5x/day (`Automations.yaml`); enrichment only runs on the `0 5 * * *` slot (or manual dispatch); the weekly `ExpiryChecker` pass and the standalone embedding pass run on their own schedules (see [[Deployment-CI-CD]]). This keeps local Ollama enrichment time bounded and means a scrape failure doesn't block enrichment of already-inserted rows, and vice versa.
 
 ## The enrichment stack, at a glance
 
 ```
-Refine/refine.py       — enrich_unenriched_jobs(): DB-driven batch loop, retry-cap logic
+Refine/refine.py       — enrich_unenriched_jobs(): DB-driven batch loop, retry-cap logic, tqdm progress
     └─ Refine/extractor.py  — JobEnricher: orchestrates regex → scrape → LLM stages per job
          ├─ RegexConstants       — pay/remote/role/experience regex, anchor-keyword filtering
-         ├─ Service/Scrapper.py::Pirate  — Playwright/requests scraping, JobPosting JSON-LD, expired detection
-         └─ Refine/llm.py::OllamaProvider — local LLM extraction, JSON repair, LLMParseError
+         ├─ Service/Scrapper.py::Pirate  — Playwright/requests scraping, ScrapeResult, JobPosting JSON-LD, blocked/expired detection
+         └─ Refine/llm.py::OllamaProvider — local LLM extraction, JSON repair, LLMParseError, check_expired()
               └─ Utils/sanitate.py::JobDataSanitizer — coerces/cleans raw LLM JSON before it touches the DB
+
+Tasks/embeddings.py    — run_embedding_pass(): standalone, decoupled from the above; embeds enriched
+                          rows and promotes qualifying ones into enrichment_examples (RAG example bank)
+
+Tasks/expired.py       — ExpiryChecker.run(): three-tier (HTTP → Playwright → LLM) weekly re-validation
+                          of active jobs, reusing Pirate.scrape_apply_url() and check_expired()
 ```
 
-See [[Enrichment-Pipeline]] for the full per-stage breakdown and [[Deployment-CI-CD]] for the actual schedule/workflow wiring.
+See [[Enrichment-Pipeline]] for the full per-stage breakdown, [[Database-Layer]] for schema/`JobDatabase` details, and [[Deployment-CI-CD]] for the actual schedule/workflow wiring.

--- a/wiki/Database-Layer.md
+++ b/wiki/Database-Layer.md
@@ -1,53 +1,86 @@
 # Database Layer
 
-`Service/db.py` — `JobDatabase`, a singleton wrapping an `asyncpg` connection pool (min 2 / max 10, SSL with hostname checking disabled).
+`Service/db.py` — `JobDatabase`, a singleton wrapping an `asyncpg` connection pool (min 2 / max 10, SSL with hostname checking disabled). Each new pool connection now also runs `register_vector()` (`pgvector.asyncpg`) so `vector` columns round-trip as `pgvector.Vector` objects instead of raw strings.
 
 ## Schema
 
 ```sql
-CREATE TABLE company (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    name TEXT UNIQUE NOT NULL,
-    company_url TEXT
-);
+CREATE TABLE company(
+     id uuid NOT NULL DEFAULT gen_random_uuid(),
+    name varchar(255),
+    company_url varchar(255),
+    created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
+    updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP ,
+    PRIMARY KEY(id) 
+); 
+CREATE UNIQUE INDEX company_name_unique ON public.company USING btree (name);
+CREATE UNIQUE INDEX company_name_unique_ci ON public.company USING btree (lower((name)::text));
 
-CREATE TABLE job_list (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    title TEXT NOT NULL,
-    company UUID REFERENCES company(id),
-    location TEXT,
-    is_remote BOOLEAN,
-    description TEXT,
-    apply_url TEXT,
-    role_type TEXT,
-    pay_range JSONB,
-    source TEXT,
-    tags JSONB DEFAULT '{}',
-    enriched BOOLEAN DEFAULT false,
-    enrich_attempts INT DEFAULT 0,
-    created_at TIMESTAMPTZ DEFAULT now(),
-    updated_at TIMESTAMPTZ DEFAULT now(),
-    UNIQUE (title, company, apply_url)
-);
+CREATE TABLE job_list(
+     id uuid NOT NULL DEFAULT gen_random_uuid(),
+    title varchar(1000),
+    company uuid,
+    location varchar(500),
+    is_remote boolean,
+    description text,
+    apply_url varchar(1000),
+    role_type varchar(255),
+    pay_range varchar(255),
+    "source" varchar(20),
+    tags json,
+    created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
+    updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
+    enriched boolean NOT NULL DEFAULT false,
+    enrich_attempts integer DEFAULT 0,
+    status text NOT NULL DEFAULT 'active'::text,
+    embedding vector,
+    summary text ,
+    PRIMARY KEY(id) ,
+    CONSTRAINT job_list_company_fkey FOREIGN key(company) REFERENCES company(id),
+    CONSTRAINT job_company_fkey FOREIGN key(company) REFERENCES company(id) 
+); 
+CREATE UNIQUE INDEX company_location_title_apply_url_1784051293594_index ON public.job_list USING btree (company, location, title, apply_url);
+
+CREATE TABLE enrichment_examples(
+     id uuid NOT NULL DEFAULT gen_random_uuid(),
+    raw_description text NOT NULL,
+    extracted_json jsonb NOT NULL,
+    embedding vector,
+    source_job_id uuid,
+    verified_by text,
+    added_at timestamp with time zone DEFAULT now(),
+    demoted boolean DEFAULT false ,
+    PRIMARY KEY(id) 
+); 
+CREATE UNIQUE INDEX uq_source_job ON public.enrichment_examples USING btree (source_job_id);
 ```
 
-> **`enrich_attempts` is referenced in code (`Refine/refine.py`) but was never added as a tracked SQL migration.** If your live DB predates the retry-cap logic, run `ALTER TABLE job_list ADD COLUMN enrich_attempts INT DEFAULT 0;` manually. There's no migrations folder in this repo — schema changes so far have all been manual `ALTER`/`CREATE` statements run directly against the DB, so it's worth keeping a running note (here, or a `migrations/` folder) of anything applied outside this file.
+> **None of `enrich_attempts`, `status`, `summary`, `embedding`, or `enrichment_examples` are tracked in a SQL migration anywhere in this repo.** There's still no `migrations/` folder — schema changes have all been manual `ALTER`/`CREATE` statements run directly against the live DB. If you're setting up a fresh DB from just the `CREATE TABLE` block above (or an older README copy of it), you'll need all of the above added by hand. This is now the third+ round of undocumented schema drift found — worth actually starting a `migrations/` folder rather than a running note.
+>
+> **Possible conflict-target mismatch:** `bulk_upsert`/`upsert` calls in `Service/azalea.py` and `Refine/refine.py` pass `conflict_column=["company", "location", "title", "apply_url"]` (4 columns, including `location`), but the `UNIQUE` constraint above is only `(title, company, apply_url)` (3 columns, no `location`). Postgres requires `ON CONFLICT (...)` to name an existing unique constraint or index exactly — if the live schema really only has the 3-column constraint, these upserts would fail at the DB level rather than silently doing the wrong thing. Worth checking what the live schema actually has (possibly a 4-column unique index was added out-of-band, same as the other undocumented drift above) and reconciling this doc, the code, and the DB.
 
 ## `JobDatabase` methods
 
 | Method | Notes |
 |---|---|
-| `create()` | classmethod, singleton — returns existing instance if pool already built |
+| `create()` | classmethod, singleton — returns existing instance if pool already built; now also registers the pgvector type on each new connection |
 | `select(table, columns, filters, raw_where, raw_params, order_by, limit)` | supports both simple `filters` dict (`col = $n`) and a `raw_where` string for anything more complex (e.g. subqueries, `LIKE`) |
 | `selectOne(...)` | thin wrapper, `limit=1` |
+| `get_or_create_company(name)` | **new.** Looks up `company` by `lower(name)`; if not found, `upsert`s a new row (`conflict_column="name"`) and returns its id. Added for `Azalea` test mode, where a JSON-backed job may carry a company name instead of a UUID |
 | `upsert(table, data, conflict_column)` | single-row insert with `ON CONFLICT ... DO UPDATE` |
 | `bulk_upsert(table, rows, conflict_column)` | same but multi-row `VALUES (...), (...), ...` in one query |
 | `update(table, data, filters)` | plain `UPDATE ... WHERE ...` |
 | `delete(table, filters)` | plain `DELETE ... WHERE ...` |
 | `call_function(fn, params, fetch_type)` | calls a Postgres function, `fetch`/`fetchval`/`fetchrow` |
-| `raw(sql, params)` | escape hatch for anything the helpers don't cover |
+| `raw(sql, params)` | escape hatch for anything the helpers don't cover — used by the expiry checker's bulk status flip and the embedding pass's similarity query |
 
-Dicts/lists in `data` values are automatically `json.dumps`'d before going to Postgres (for the `tags`/`pay_range` JSONB columns).
+## Value serialization: `_serialize()` (new)
+
+Previously `upsert`/`bulk_upsert` inlined `json.dumps(v) if isinstance(v, (dict, list)) else v` for every column value. That's now a dedicated `_serialize(v)` method:
+
+- `pgvector.Vector` values pass through untouched — the asyncpg + pgvector driver handles the wire format directly
+- `dict`/`list` values go through `json.dumps(v, default=self._json_default)` — the new `_json_default` stringifies `uuid.UUID` and `datetime.date`/`datetime.datetime` objects, so a `tags` or `pay_range` payload that happens to contain one of those no longer raises `TypeError: Object of type UUID is not JSON serializable`
+- everything else passes through unchanged
 
 ## The COALESCE upsert pattern
 
@@ -61,6 +94,6 @@ DO UPDATE SET
     ...
 ```
 
-This means re-scraping a job that already exists **never nulls out** a field that was previously enriched — a fresh scrape only has `title`/`location`/`apply_url`/`source`, so `description`, `pay_range`, etc. would otherwise get wiped to `NULL` on every re-scrape. COALESCE prevents that: only a non-null incoming value overwrites the existing one.
+This means re-scraping a job that already exists **never nulls out** a field that was previously enriched — a fresh scrape only has `title`/`location`/`apply_url`/`source`, so `description`, `summary`, `pay_range`, etc. would otherwise get wiped to `NULL` on every re-scrape. COALESCE prevents that: only a non-null incoming value overwrites the existing one.
 
 This is also why enrichment can safely run independently of scraping — a scrape never regresses an already-enriched row. The one place this pattern is deliberately *not* used is `_apply_structured_data()` in the enrichment pipeline (see [[Enrichment-Pipeline]]), which overwrites fields in-memory on the `Job` object when a schema.org `JobPosting` block is found — that overwritten value then flows through the normal `upsert()` afterward.

--- a/wiki/Deployment-CI-CD.md
+++ b/wiki/Deployment-CI-CD.md
@@ -1,12 +1,14 @@
 # Deployment & CI/CD
 
-Three GitHub Actions workflows, all deploying via SSH to a DigitalOcean droplet at `/var/www/libra/`, running under a `libra` virtualenv and a `libra` systemd service.
+Five GitHub Actions workflows, most deploying via SSH to a DigitalOcean droplet at `/var/www/libra/`, running under a `libra` virtualenv and a `libra` systemd service.
 
 ## `deploy.yaml` — API deploy
 
 Trigger: push to `master`. Pulls latest code (`git reset --hard origin/master`), reinstalls requirements, `sudo systemctl restart libra`. Discord notification on success/failure via webhook + role mention.
 
-## `scarpe.yaml` — scrape + enrich cron
+## `Automations.yaml` — scrape + enrich + expire cron
+
+This replaces the old single scrape/enrich workflow (previously named `scarpe.yaml`, since renamed and restructured into three jobs). Schedule:
 
 ```
 0 5 * * *   → 12 AM EST
@@ -18,18 +20,23 @@ Trigger: push to `master`. Pulls latest code (`git reset --hard origin/master`),
 
 (also `workflow_dispatch` for manual runs)
 
-- **`scrape` job**: runs on every scheduled trigger — SSHes in, pulls latest, runs `Tasks/scrape.py`, logs to `logs/scrape.log`
-- **`enrich` job**: `needs: scrape`, but only actually runs when the trigger is the `0 5 * * *` cron slot or a manual `workflow_dispatch` — i.e. enrichment runs once a day, not on every scrape cycle, to bound local Ollama enrichment time
+- **`scrape` job**: runs on every scheduled trigger — SSHes in, `git reset --hard origin/master`, reinstalls requirements, runs `Tasks/scrape.py`, logs to `logs/scrape.log`. Notifies Discord on failure only.
+- **`enrich` job**: `needs: scrape`, but only actually runs when the trigger is the `0 5 * * *` cron slot or a manual `workflow_dispatch` — i.e. enrichment runs once a day, not on every scrape cycle. Runs `Tasks/enrich.py`, logs to `logs/enrich.log`. Notifies Discord on failure only.
+- **`expired` job**: gated on `github.event.schedule == '0 6 * * 6'` (Saturday 6 AM UTC) or manual dispatch — **note this cron expression isn't actually one of the five listed under `on.schedule` above**, so as written this job's `if` condition can only ever be satisfied by a manual `workflow_dispatch`, never by the schedule itself (see [[Roadmap]]). Runs `Tasks/expired.py`, logs to `logs/expired.log`, and notifies Discord on **both** success and failure (unlike the other two jobs), attaching the log file to the message.
 
-Both jobs post a Discord failure notification if the SSH step fails; success isn't announced for these (only for `deploy.yaml`).
+`Tasks/embeddings.py` (the new standalone embedding/RAG pass) has **no job in this workflow at all** — it isn't scheduled anywhere yet. It must be run manually on the droplet until a job is added.
+
+## `PR checklist.yaml`
+
+Runs a concurrency-controlled checklist check on pull requests (see the repo's `.github/PULL_REQUEST_TEMPLATE.md` for what the checklist itself covers). Not tied to deploy/scrape — purely a PR gate.
+
+## `wiki-sync.yaml`
+
+Syncs the `wiki/` folder in this repo to the GitHub Wiki on push, so the pages here (this one included) stay mirrored without a manual publish step. This is the workflow whose output you're reading if you're viewing this on the GitHub Wiki rather than in-repo.
 
 ## `notify.yaml` — general repo activity
 
 Separate from deploy/scrape — fires on push to **any** branch and on issue open/reopen/close. Posts to Discord with commit info (repo, branch, SHA, message, author) or issue info (title, opener, link). This is the one that pings on every push regardless of whether it's `master`.
-
-## Typo note
-
-The scrape workflow file is named `scarpe.yaml` (transposed letters) — harmless since GitHub Actions doesn't care about filenames, but worth knowing if you're hunting for it.
 
 ## Secrets required
 

--- a/wiki/Diagrams.md
+++ b/wiki/Diagrams.md
@@ -10,7 +10,6 @@ Mermaid class + sequence diagrams for most modules live in the main repo under [
 | `JobSource/base.py` | [base_class.md](https://github.com/AustinDwomoh/Libra/blob/master/docs/diagrams/base_class.md) | [base_seq.md](https://github.com/AustinDwomoh/Libra/blob/master/docs/diagrams/base_seq.md) |
 | `JobSource/simplify.py` | [simplify_class.md](https://github.com/AustinDwomoh/Libra/blob/master/docs/diagrams/simplify_class.md) | [simplify_seq.md](https://github.com/AustinDwomoh/Libra/blob/master/docs/diagrams/simplify_seq.md) |
 | `JobSource/jsearch.py` | [jsearch_class.md](https://github.com/AustinDwomoh/Libra/blob/master/docs/diagrams/jsearch_class.md) | [jsearch_seq.md](https://github.com/AustinDwomoh/Libra/blob/master/docs/diagrams/jsearch_seq.md) |
-| `JobSource/remote.py` | [remote_class.md](https://github.com/AustinDwomoh/Libra/blob/master/docs/diagrams/remote_class.md) | [remote_seq.md](https://github.com/AustinDwomoh/Libra/blob/master/docs/diagrams/remote_seq.md) |
 | `Refine/extractor.py` (`JobEnricher`) | [extractor_class.md](https://github.com/AustinDwomoh/Libra/blob/master/docs/diagrams/extractor_class.md) | [extractor_seq.md](https://github.com/AustinDwomoh/Libra/blob/master/docs/diagrams/extractor_seq.md) |
 | `Refine/llm.py` (`OllamaProvider`) | [llm_class.md](https://github.com/AustinDwomoh/Libra/blob/master/docs/diagrams/llm_class.md) | [llm_seq.md](https://github.com/AustinDwomoh/Libra/blob/master/docs/diagrams/llm_seq.md) |
 | `Refine/refine.py` | [refine_class.md](https://github.com/AustinDwomoh/Libra/blob/master/docs/diagrams/refine_class.md) | [refine_seq.md](https://github.com/AustinDwomoh/Libra/blob/master/docs/diagrams/refine_seq.md) |
@@ -19,14 +18,32 @@ Mermaid class + sequence diagrams for most modules live in the main repo under [
 | `Utils/sanitate.py` (`JobDataSanitizer`) | [sanitate_class.md](https://github.com/AustinDwomoh/Libra/blob/master/docs/diagrams/sanitate_class.md) | — |
 | `Tasks/scrape.py` | — | [scrape_seq.md](https://github.com/AustinDwomoh/Libra/blob/master/docs/diagrams/scrape_seq.md) |
 | `Tasks/enrich.py` | — | [enrich_seq.md](https://github.com/AustinDwomoh/Libra/blob/master/docs/diagrams/enrich_seq.md) |
+| `Tasks/expired.py` (`ExpiryChecker`) | [expired_class.md](https://github.com/AustinDwomoh/Libra/blob/master/docs/diagrams/expired_class.md) **(new)** | [expired_seq.md](https://github.com/AustinDwomoh/Libra/blob/master/docs/diagrams/expired_seq.md) **(new)** |
+| `Tasks/embeddings.py` | [embeddings_class.md](https://github.com/AustinDwomoh/Libra/blob/master/docs/diagrams/embeddings_class.md) **(new)** | [embeddings_seq.md](https://github.com/AustinDwomoh/Libra/blob/master/docs/diagrams/embeddings_seq.md) **(new)** |
 | `main.py` (API routes) | — | [main_api_seq.md](https://github.com/AustinDwomoh/Libra/blob/master/docs/diagrams/main_api_seq.md) |
 
-All diagrams above are current as of the `testing-ollama-deepseek` merge (`JobEnricher`, `Pirate`, `JobDataSanitizer`, `OllamaProvider`, `LLMParseError`). `extractor_class.md`, `extractor_seq.md`, `llm_class.md`, `llm_seq.md`, `refine_class.md`, and `refine_seq.md` were regenerated to replace stale versions describing the old function-based `extractor.py` and Groq-only `llm.py`. `scrapper_class.md`, `scrapper_seq.md`, and `sanitate_class.md` are new additions for modules that previously had no diagram at all.
+`JobSource/remote.py` has no diagram because it doesn't exist — `RemoteOK` is an unimplemented `JobSource` enum value with no helper class anywhere in the repo. See [[Roadmap]].
+
+## What changed in this pass
+
+Regenerated to catch up with everything merged since the last sync (`d6fa990` → current `master`), which touched `Refine/extractor.py`, `Refine/refine.py`, `Service/Scrapper.py`, `Service/azalea.py`, `Service/db.py`, `Tasks/expired.py`, `Utils/constants.py`, `Utils/models.py`, `Utils/notify.py`, `Utils/sanitate.py`, and added the new `Tasks/embeddings.py`:
+
+- **`extractor_class.md` / `extractor_seq.md`** — `Pirate.scrape_apply_url()` now returns a `ScrapeResult` dataclass instead of a bare `str`; `description` is filled directly from scraped text rather than by the LLM; the LLM now returns a separate `summary` + `description_looks_valid`; noted that `_run_scrape()` doesn't distinguish a blocked-scrape dict from a structured-data dict.
+- **`scrapper_class.md` / `scrapper_seq.md`** — new `ScrapeResult` dataclass, `BLOCKED_STATUS_CODES` (403/429) handling, `_trim_to_description()` window-narrowing, `_trim_trailing_cookie_banner()` fallback.
+- **`refine_class.md` / `refine_seq.md`** — `tqdm` progress bar + background refresh thread around the batch loop; RAG example-bank promotion moved out to `Tasks/embeddings.py`; flagged the new `from the import get_job_by_id` broken import.
+- **`db_class.md` / `db_seq.md`** — new `get_or_create_company()` method, `_serialize()`/`_json_default()` replacing the inline `json.dumps` check, pgvector `Vector` type registration on pool connections.
+- **`sanitate_class.md`** — new `_normalise_description_valid()` step; removed the now-defunct `_MAX_TAGS` cap.
+- **`models_class.md`** — added the new `summary` field, updated the hash/eq note.
+- **`constants_class.md`** — logging now also writes to `logs/run.log`; `is_missing()` covers more stringified-empty cases; prompt schema notes (`summary`/`description_looks_valid` replacing `description`, `_MAX_TAGS` removed).
+- **`azalea_class.md` / `azalea_seq.md`** — corrected a pre-existing inaccuracy (RemoteOK was never actually registered as a helper, despite the diagram previously implying it was gated behind a toggle bug); test-mode JSON cap tightened to 10 jobs; new `get_or_create_company()` fallback; `domains_to_ignore` grew to include `bebee`/`lensa`; test-mode enrichment batch size tightened to 5.
+- **`main_api_seq.md`** — corrected `/jobs`, `/company`, and `/search` to their actual `ORDER BY created_at ASC` (the diagram previously said `DESC` for all four routes; only `/sponsor` is actually `DESC`), and added the `enriched=true AND status='active'` filters that were missing from all four.
+- **`expired_class.md` / `expired_seq.md`** — new. `Tasks/expired.py::ExpiryChecker` had no diagram at all before this pass, despite predating most of the other recent changes.
+- **`embeddings_class.md` / `embeddings_seq.md`** — new, for the brand-new `Tasks/embeddings.py`.
 
 ## Higher-level diagrams (kept in the wiki, not per-module)
 
-[[Architecture]] has the full pipeline flowchart and the enrichment-stack tree; [[Enrichment-Pipeline]] has the `JobEnricher.enrich_job()` decision flow reflecting the current structured-data/expired/garbage branching.
+[[Architecture]] has the full pipeline flowchart and the enrichment-stack tree; [[Enrichment-Pipeline]] has the `JobEnricher.enrich_job()` decision flow reflecting the current `ScrapeResult`/structured/blocked branching.
 
 ## Keeping these in sync
 
-If a module's class shape changes meaningfully, regenerate its diagram pair rather than hand-editing — hand-edits drift silently, as happened here.
+If a module's class shape changes meaningfully, regenerate its diagram pair rather than hand-editing — hand-edits drift silently.

--- a/wiki/Enrichment-Pipeline.md
+++ b/wiki/Enrichment-Pipeline.md
@@ -1,25 +1,25 @@
 # Enrichment Pipeline
 
-Four files now: `Service/Scrapper.py` (`Pirate`), `Refine/extractor.py` (`JobEnricher`, `RegexConstants`), `Refine/llm.py` (`LLMProvider`, `OllamaProvider`, `LLMParseError`), `Utils/sanitate.py` (`JobDataSanitizer`). Goal is unchanged: fill `pay_range`, `is_remote`, `role_type`, `location`, `tags`, `description` without ever overwriting a field that's already populated — except structured markup from the employer's own page, which is treated as authoritative and does overwrite.
+Four files: `Service/Scrapper.py` (`Pirate`), `Refine/extractor.py` (`JobEnricher`, `RegexConstants`), `Refine/llm.py` (`LLMProvider`, `OllamaProvider`, `LLMParseError`), `Utils/sanitate.py` (`JobDataSanitizer`). Goal is unchanged: fill `pay_range`, `is_remote`, `role_type`, `location`, `tags`, `description` (and now `summary`) without ever overwriting a field that's already populated — except structured markup from the employer's own page, which is treated as authoritative and does overwrite.
 
 ## Provider: Ollama, not Groq
 
-`llm.py` currently ships with **`OllamaProvider`** as the only active provider — `deepseek-r1:8b`, run fully locally via `pip install ollama` + `ollama pull deepseek-r1:8b`. The old `GroqProvider` class is still in the file but fully commented out ("Trying to fully rely on Ollama for now, since Groq is a paid service and Ollama is free and local"). If you ever need to swap back or add a new provider, subclass `LLMProvider` and implement `complete(prompt) -> str`.
+`llm.py` ships with **`OllamaProvider`** as the only active provider — `deepseek-r1:8b`, run fully locally via `pip install ollama` + `ollama pull deepseek-r1:8b`. The old `GroqProvider` class is still in the file but fully commented out. If you ever need to swap back or add a new provider, subclass `LLMProvider` and implement `complete(prompt) -> str`. `LLMProvider` also exposes `check_expired(text)` — a narrow, dedicated call used only by the [[Roadmap|weekly expiry checker]], never by the main enrichment path.
 
 ## Entry point: `refine.py` → `enrich_unenriched_jobs()`
 
 Called from `Tasks/enrich.py` (or manually). Per batch:
 
-1. `db.select("job_list", filters={"enriched": False}, limit=batch_size)` — oldest unenriched rows first
+1. `db.select("job_list", filters={"enriched": False, "status": "active"}, order_by="created_at DESC", limit=batch_size)` — newest unenriched active rows first, so the jobs most likely to still be relevant get enriched before older ones
 2. Fast-path skip if nothing in `ENRICH_FIELDS` is actually missing
-3. `_row_to_job(row)` reconstructs a `Job` from the DB row
-4. A **fresh `JobEnricher` instance is created per job** and its `.enrich_job(job)` method is called — this matters because `JobEnricher.__init__` builds a `self.meta` dict that isn't reset between calls, so reusing one instance across a batch would silently accumulate `fields_filled`/`stages_run` from every prior job into each result
+3. `_row_to_job(row)` reconstructs a `Job` from the DB row — now also normalizes `tags` if the DB handed it back as a raw JSON string (`"{}"`, `"null"`, etc.) instead of an already-parsed dict
+4. A **fresh `JobEnricher` instance is created per job** and its `.enrich_job(job)` method is called — `JobEnricher.__init__` builds a `self.meta` dict that isn't reset between calls, so reusing one instance across a batch would silently accumulate `fields_filled`/`stages_run` from every prior job into each result
 5. Persist via `db.upsert(...)` with `enriched=True`
-6. `llm_delay` (default 0.5s) sleep between rows
+6. `llm_delay` (default 0.5s) sleep between rows, skipped after the last row
 
-New failure handling: if the LLM call raises `LLMParseError` (output unparseable even after repair), the row's `enrich_attempts` counter increments. Once it hits `MAX_ENRICH_ATTEMPTS` (3), the job is marked `enriched=True` anyway so it stops being retried forever. Any other exception (network, DB) is treated as transient — the row is left `enriched=False` and picked up again next run.
+Failure handling is unchanged: if the LLM call raises `LLMParseError` (output unparseable even after repair), the row's `enrich_attempts` counter increments. Once it hits `MAX_ENRICH_ATTEMPTS` (3), the job is marked `enriched=True` anyway so it stops being retried forever. Any other exception (network, DB) is treated as transient — the row is left `enriched=False` and picked up again next run.
 
-> ⚠️ **Bug found and fixed (see repo history):** `refine.py` was importing a top-level `enrich_job` function from `extractor.py` that no longer exists after the `JobEnricher` refactor — this broke `enrich_unenriched_jobs()` entirely (`ImportError` at module load). Fixed by importing `JobEnricher` and instantiating it per-job instead.
+**New in this pass:** the whole per-row body now runs inside a `tqdm` progress bar (with a background thread calling `pbar.refresh()` once a second so the bar keeps moving during long, silent LLM calls), and the final log line now also lists the enriched job IDs/titles for that run.
 
 ## `JobEnricher.enrich_job()` — the pipeline stages
 
@@ -32,45 +32,67 @@ flowchart TD
     Missing2 -->|No| Done1[Done]
     Missing2 -->|Yes| Scrape["_run_scrape(): Pirate.scrape_apply_url()"]
     Scrape --> Type{Result type?}
-    Type -->|dict = structured JobPosting JSON-LD| Structured["_apply_structured_data(): OVERWRITES existing fields, authoritative"]
-    Type -->|str = rendered text| Classify["Pirate.classify_scraped_text(): ok / expired / garbage"]
+    Type -->|dict = structured JobPosting OR blocked| Structured["_apply_structured_data(): OVERWRITES existing fields\n(blocked dicts are NOT distinguished here — see note below)"]
+    Type -->|ScrapeResult = raw_text + trimmed_text| Classify["Pirate.classify_scraped_text(raw_text): ok / expired / garbage"]
     Type -->|None = scrape failed| Done2[Done]
     Structured --> Missing3{Still missing?}
-    Missing3 -->|Yes| LLMStruct[LLM on structured description]
+    Missing3 -->|Yes| LLMStruct[LLM on structured description → summary + description_looks_valid + job_expired]
     Missing3 -->|No| Done3[Done]
-    Classify -->|expired| MarkExpired[_mark_expired: overwrite description, stop]
+    Classify -->|expired| MarkExpired[_mark_expired: status=expired, stop]
     Classify -->|garbage| Done4[Done, no further action]
-    Classify -->|ok| RegexScraped[Re-run regex on scraped text]
-    RegexScraped --> Missing4{Still missing?}
-    Missing4 -->|Yes| LLMScraped[LLM on scraped text]
+    Classify -->|ok| RegexScraped[Re-run regex on raw_text; description filled from trimmed_text]
+    RegexScraped --> Missing4{description was missing before this fill?}
+    Missing4 -->|Yes| LLMScraped[LLM on trimmed_text → summary + description_looks_valid + job_expired]
     Missing4 -->|No| Done5[Done]
 ```
 
 ### Stage 1 — Regex (`RegexConstants`, in `extractor.py`)
 
-Same fields as before (pay, remote, role type, experience years) but the pay regex is meaningfully hardened:
-
-- **Anchor-keyword logic**: a bare number range with no currency symbol, no `k` suffix, and no captured time unit (e.g. "10-15") needs a nearby pay-related keyword (`salary`, `compensation`, `per hour`, etc.) within 25 chars to be trusted — otherwise it's rejected. This exists specifically to stop "10-15 years experience" from being misread as a salary range.
-- **Veto keywords**: even *with* a nearby pay keyword, terms like `years`, `employees`, `reports`, `reviews` right next to the number veto the match.
-- **k-suffix propagation**: `"90-110k"` only has the `k` on the second number in the raw regex match — it's now propagated to the first number too, so `90` doesn't get read as `$90` instead of `$90,000`.
+Unchanged: pay/remote/role-type/experience regex with anchor-keyword logic (a bare number range needs a nearby pay keyword within 25 chars to be trusted), veto keywords (`years`, `employees`, `reports`, `reviews` next to a number veto the match), and `k`-suffix propagation (`"90-110k"` → both numbers get the `k`).
 
 ### Stage 2 — Scrape (`Pirate.scrape_apply_url`, in `Service/Scrapper.py`)
 
-This absorbed what used to be inline in `extractor.py`, plus new capability:
+Returns one of three shapes now, and the distinction matters more than before:
 
-- **Structured data first**: before falling back to rendered-text scraping, it looks for a schema.org `JobPosting` JSON-LD `<script>` block in the page — most ATS platforms (Workday, Greenhouse, Lever) embed this for Google for Jobs indexing. If found, it's parsed into `{description, location, is_remote, pay_range, job_expired}` and returned as a **dict** rather than a string — callers know to treat this as ground truth and overwrite, not merge.
-- **Expired-redirect detection**: `_SITE_EXPIRED_URL_PATTERNS` matches known dead-link redirect patterns per domain (LinkedIn's `trk=expired_jd_redirect`, Workday's `/error`/`/notfound`/`sessionTimedOut`) and bails out early with `None` rather than scraping a dead page.
-- **Workday-specific wait**: if the URL is `myworkdayjobs.com`, it waits for the `[data-automation-id="jobPostingDescription"]` selector before reading content, since Workday renders the description asynchronously.
-- **Multi-frame text extraction**: checks `page.frames` and keeps whichever frame has the longest extracted text — some ATS platforms render the actual posting inside an iframe.
-- **Cookie-banner stripping**: removes elements matching cookie/consent id/class patterns before extracting text, and a regex (`_COOKIE_NOTICE_RE`) strips leftover cookie-notice boilerplate from the extracted text.
-- **`classify_scraped_text()`**: after getting rendered text (not structured data), classifies it as `"expired"` (matches known expired-listing phrases), `"garbage"` (login walls, Cloudflare challenge pages, 403/404 text, or just too short — under 300 chars), or `"ok"`.
+- **A `dict`** — either a schema.org `JobPosting` JSON-LD block (authoritative, `{description, location, is_remote, pay_range, job_expired}`) **or** a new `{"blocked": True, "status_code": 403|429}` shape returned when the site actively refused the request. `_run_scrape()` currently treats **any** dict the same way — it doesn't check for `blocked` before calling `_apply_structured_data()` on it. In practice a blocked dict has none of the expected keys, so it's a harmless no-op rather than a crash, but it also means a blocked scrape silently looks like "nothing to apply" instead of being logged or retried as blocked — worth fixing (contrast with `Tasks/expired.py`'s `_deep_check()`, which does check `scraped.get("blocked")` explicitly and counts it separately).
+- **A `ScrapeResult` dataclass** (`raw_text`, `trimmed_text`) — replaces the old bare `str` return. `raw_text` is the full cookie-stripped page text, used for regex and `classify_scraped_text()`. `trimmed_text` is narrowed by the new `_trim_to_description()` to the window between a start marker ("responsibilities", "about the role", "about the team", "what you'll do") and an end marker ("job information", "why join us", "diversity & inclusion", "equal employment opportunity", "accommodation") — this is what fills `job.description` directly and what gets sent to the LLM, so boilerplate sections no longer dilute either.
+- **`None`** — scrape failed or hit a known-expired redirect.
+
+Other scrape-stage capabilities, unchanged: structured-data-first lookup, `_SITE_EXPIRED_URL_PATTERNS` expired-redirect detection, Workday-specific selector wait, multi-frame text extraction (longest frame wins), and a two-layer cookie-banner strip (`_strip_cookie_boilerplate` regexes plus the new `_trim_trailing_cookie_banner()` fallback, which looks for known cookie phrases in the last 600 chars and cuts everything from there onward rather than matching exact vendor wording). New: `BLOCKED_STATUS_CODES = {403, 429}` is checked immediately after both the Playwright `page.goto()` response and the `requests` fallback, before any expired-redirect or content parsing runs.
+
+`classify_scraped_text()` itself is unchanged: `"expired"` / `"garbage"` (login walls, Cloudflare challenge pages, or under 300 chars) / `"ok"`.
 
 ### Stage 3 — LLM (`OllamaProvider.extract`, via `LLMProvider.extract`)
 
-- Prompt (`Utils/constants.py::LLMConstants._LLM_PROMPT`) now asks for a richer `tags` structure — `requirements`, `preferred`, `skills`, `technologies`, `certifications` as separate lists, not just a flat skill/experience dict — plus a `job_expired` boolean the model can set if the scraped text itself signals a dead posting.
-- **JSON repair pipeline** (`_try_repair_json` in `llm.py`): if the raw response doesn't parse as JSON, it tries (in order) the optional `json_repair` library, smart-quote normalization, trailing-comma stripping, single-quote-to-double-quote conversion (only if there are no legitimate double quotes already), and finally a regex pull of the first `{...}` block. If none of that works, raises `LLMParseError` rather than silently returning `{}` like the old Groq-only version did — this is what feeds the `enrich_attempts` retry-cap logic in `refine.py`.
-- **`JobDataSanitizer.sanitize()`** (`Utils/sanitate.py`) runs on every successfully parsed response before it touches the `Job`/DB: clamps `pay_range` to numeric-or-None and swaps min/max if reversed, coerces `role_type` to a canonical enum value (falling back to keyword matching, then `"other"`), coerces `is_remote` to strict `True`/`False`/`None` from whatever string variant the model returned, forces `job_expired` to a strict bool, flattens/cleans `tags` to `dict[str, str]` capped at `_MAX_TAGS` entries, and truncates free-text fields to their configured length limits.
+The output schema changed. The prompt (`Utils/constants.py::LLMConstants._LLM_PROMPT`) now asks for:
 
-## Key invariant, unchanged
+- **`summary`** (2–4 sentences, in the model's own words) instead of the old `description` field — `job.description` is now filled directly from the scraped `trimmed_text`, not generated by the LLM. The LLM's `summary` only lands on `job.summary` (a new field — see [[Database-Layer]]), and only if `job.summary` was still missing.
+- **`description_looks_valid`** (bool) — true if the scraped text read as an actual job description, false if it looked like navigation, an error/login page, or garbled text. A `false` here doesn't block the description fill; it just appends a warning to `self.meta["warnings"]`.
+- **`job_expired`** — now specified in the prompt to never return `null`, only `true`/`false`.
+- Pay-range guidance in the prompt was rewritten with concrete before/after examples (`"$45/hr"` → `[45, null]`, explicitly **not** annualized into both slots) instead of prose rules.
+- **`tags`** — unchanged shape (`requirements`, `preferred`, `skills`, `technologies`, `certifications`, `experience_years`), but the old `_MAX_TAGS = 11` cap and the per-value 100-char truncation in `JobDataSanitizer._normalise_tags()` have both been removed — tags are no longer artificially capped or truncated.
 
-`_apply_to_job()` still only ever writes a field if `Config.is_missing(current_value)` — this is what makes repeated enrichment passes safe. The one deliberate exception is `_apply_structured_data()`, used only for schema.org JobPosting data, which **does overwrite** on the reasoning that vendor-supplied structured markup is more trustworthy than whatever value came from the original scrape source.
+**JSON repair pipeline** (`_try_repair_json` in `llm.py`) is unchanged: optional `json_repair` library → smart-quote normalization → trailing-comma stripping → single-to-double-quote conversion → regex pull of the first `{...}` block → `LLMParseError` if nothing works.
+
+**`JobDataSanitizer.sanitize()`** (`Utils/sanitate.py`) now runs an extra step: `_normalise_description_valid()`, which coerces `description_looks_valid` into a strict bool (defaulting to `True`/fail-open if missing or unparseable). Everything else — pay clamping, role-type coercion, `is_remote` coercion, `job_expired` bool coercion, text-field length limits (now keyed on `summary`, not `description`) — is unchanged in shape, just no longer tag-capped.
+
+## `_apply_to_job()` — merge logic, reworked
+
+Still only writes non-tag fields if `Config.is_missing(current_value)`. What changed:
+
+- `job_expired` is now explicitly skipped as a pure control signal (handled by the caller via `_mark_expired`), regardless of whether the caller already popped it — so this function stays safe to call even if a future caller forgets to pop it first.
+- **Tags merging is more defensive.** `job.tags` can come back from the DB as a raw JSON string instead of an already-parsed dict; `_apply_to_job` now normalizes that (`json.loads`, falling back to `{}` on a parse error) before merging, and always writes the normalized dict back onto `job.tags` even when nothing new was actually added — so the type stays consistent for the next stage.
+- `Config.is_missing()` itself grew new cases: the literal strings `"{}"`, `"[]"`, `"null"`, and `"None"` now count as missing, alongside the existing `""`, `"Unknown"`, `"other"`, `"unknown"`.
+
+`_apply_structured_data()` is unchanged in behavior: used only for schema.org JobPosting data, and **does overwrite**, on the reasoning that vendor-supplied structured markup is more trustworthy than the original scrape source.
+
+## New, separate: `Tasks/embeddings.py` — standalone embedding + example-bank pass
+
+Not part of `enrich_unenriched_jobs()` anymore. `run_embedding_pass(batch_size=50)`:
+
+1. Pulls `job_list` rows where `enriched=True` and `enrich_attempts < 5`
+2. For each, builds an embedding-input string from title + description + tags (`skills`/`technologies`/`requirements`), embeds it via a direct HTTP call to `http://localhost:11434/api/embeddings` (model `nomic-embed-text`), and writes the resulting `pgvector` `Vector` onto `job_list.embedding`
+3. Reuses that same embedding (no re-embedding) to evaluate promotion into `enrichment_examples` via `maybe_promote_to_example_bank()` — skipped if `enrich_attempts > 1`, if the job fails `passes_sanity_checks()` (valid `role_type`, sane `pay_range`, real `location`, `description` ≥ 50 chars), or if it's cosine-similarity ≥ 0.95 to an existing example
+4. Posts a Discord summary via `notify_discord(..., file_path="embedded_jobs.txt")` on completion
+
+This is not yet wired into any GitHub Actions workflow — see [[Deployment-CI-CD]] and [[Roadmap]]. It must currently be run manually.

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -2,19 +2,19 @@
 
 Internal reference for the Libra job-scraping/enrichment pipeline. This is not user-facing docs — it's here so future-me (or anyone else touching this) doesn't have to re-derive the architecture from scratch.
 
-**What Libra does:** pulls job postings from Simplify's GitHub README, the JSearch API, and RemoteOK, dedupes them, stores them in Postgres, runs an LLM enrichment pass (**Ollama**, running `deepseek-r1:8b` locally) to fill in missing fields (pay range, remote status, role type, sponsorship signals, tags), and serves everything read-only through a FastAPI.
+**What Libra does:** pulls job postings from Simplify's GitHub README and the JSearch API, dedupes them, stores them in Postgres, runs an LLM enrichment pass (**Ollama**, running `deepseek-r1:8b` locally) to fill in missing fields (pay range, remote status, role type, description, summary, tags), periodically re-validates active listings for expiry, and serves everything read-only through a FastAPI. A standalone embedding pass also builds a pgvector-backed RAG example bank for future use.
 
 **Live API:** `http://libra.austindwomoh.xyz` · Swagger: `/docs`
 
 ## Pages
 
-- [[Architecture]] — end-to-end data flow, source → dedupe → DB → enrich → API
-- [[Enrichment-Pipeline]] — how `extractor.py` / `llm.py` / `refine.py` fit together, the 3-stage fill logic
-- [[Database-Layer]] — schema, `JobDatabase`, the COALESCE upsert pattern
+- [[Architecture]] — end-to-end data flow, source → dedupe → DB → enrich → embed/expire → API
+- [[Enrichment-Pipeline]] — how `extractor.py` / `llm.py` / `refine.py` / `Scrapper.py` fit together, the stage-by-stage fill logic
+- [[Database-Layer]] — schema, `JobDatabase`, the COALESCE upsert pattern, pgvector
 - [[API-Reference]] — every FastAPI route, params, response shape
 - [[Deployment-CI-CD]] — GitHub Actions workflows, cron schedule, SSH deploy
 - [[Diagrams]] — index of all Mermaid class/sequence diagrams in `docs/diagrams`
-- [[Roadmap]] — planned/unfinished work
+- [[Roadmap]] — planned/unfinished work, known bugs
 
 ## Repo map
 
@@ -22,24 +22,28 @@ Internal reference for the Libra job-scraping/enrichment pipeline. This is not u
 Libra/
 ├── main.py              # FastAPI app + routes
 ├── Service/
-│   ├── azalea.py        # orchestrator: fetch → dedup → self.jobs → fin_jobs → upsert
-│   ├── db.py            # asyncpg pool + CRUD (select/upsert/update/delete)
-│   └── Scrapper.py      # Pirate: Playwright/requests scraping, JobPosting JSON-LD, expired detection
+│   ├── azalea.py         # orchestrator: fetch → dedup → self.jobs → fin_jobs → upsert
+│   ├── db.py              # asyncpg pool + CRUD (select/upsert/update/delete), pgvector-aware
+│   └── Scrapper.py        # Pirate: Playwright/requests scraping, ScrapeResult, JobPosting JSON-LD, blocked/expired detection
 ├── JobSource/
-│   ├── simplify.py       # scrapes Simplify's GitHub README tables
-│   ├── jsearch.py        # JSearch (OpenWebNinja) API
-│   └── remote.py         # RemoteOK API
+│   ├── simplify.py        # scrapes Simplify's GitHub README tables
+│   ├── jsearch.py         # JSearch (OpenWebNinja) API
+│   └── base.py            # shared helper base
+│   # NOTE: no remote.py — RemoteOK is a JobSource enum value with no
+│   #       implementation or registered helper. See Roadmap.
 ├── Refine/
-│   ├── extractor.py      # JobEnricher: regex stage + Pirate scrape stage + LLM stage
-│   ├── llm.py            # LLMProvider ABC, OllamaProvider, LLMParseError, JSON repair
-│   └── refine.py         # enrich_unenriched_jobs() — DB-driven enrichment loop, retry-cap logic
+│   ├── extractor.py       # JobEnricher: regex stage + Pirate scrape stage + LLM stage
+│   ├── llm.py              # LLMProvider ABC, OllamaProvider, LLMParseError, JSON repair, check_expired()
+│   └── refine.py           # enrich_unenriched_jobs() — DB-driven enrichment loop, retry-cap logic
 ├── Utils/
-│   ├── models.py         # Job, Company, JobStats dataclasses
-│   ├── constants.py      # Config, enums, LLMConstants (prompt template)
-│   ├── sanitate.py       # JobDataSanitizer — cleans/coerces raw LLM JSON
-│   └── notify.py         # Discord webhook helper
+│   ├── models.py           # Job (now with summary), Company, JobStats dataclasses
+│   ├── constants.py        # Config, enums, LLMConstants (prompt template)
+│   ├── sanitate.py         # JobDataSanitizer — cleans/coerces raw LLM JSON
+│   └── notify.py           # Discord webhook helper
 ├── Tasks/
-│   ├── scrape.py         # CLI entrypoint: runs Azalea.run()
-│   └── enrich.py         # standalone enrich + Discord embed poster
-└── docs/diagrams/         # Mermaid class + sequence diagrams, one pair per module
+│   ├── scrape.py           # CLI entrypoint: runs Azalea.run()
+│   ├── enrich.py           # standalone enrich + Discord embed poster
+│   ├── expired.py          # ExpiryChecker: weekly tiered re-validation of active jobs
+│   └── embeddings.py       # standalone embedding + RAG example-bank promotion pass (new, not yet scheduled)
+└── docs/diagrams/          # Mermaid class + sequence diagrams, one pair per module
 ```

--- a/wiki/Roadmap.md
+++ b/wiki/Roadmap.md
@@ -1,36 +1,41 @@
 # Roadmap / Open Threads
 
-Things planned, half-wired, or recently fixed — worth checking before assuming otherwise.
+Things planned, half-wired, broken, or recently fixed — worth checking before assuming otherwise.
 
-## Recently fixed
+## 🔴 Active bugs (found during this pass)
 
-- **`Refine/refine.py` import bug**: it was importing a top-level `enrich_job` function from `Refine/extractor.py` that no longer existed after the `JobEnricher` class refactor (part of the `testing-ollama-deepseek` merge). This broke `enrich_unenriched_jobs()` entirely — an `ImportError` at module load, meaning both `Service/azalea.py`'s enrichment call and `Tasks/enrich.py` would have crashed. Fixed by importing `JobEnricher` and instantiating a fresh instance per job (needed because `JobEnricher.meta` is built once in `__init__` and isn't reset between calls, so reusing one instance across a batch would silently accumulate stats across jobs).
+- **`ExpiryChecker`'s weekly schedule can never actually fire from its own cron.** `Automations.yaml`'s `expired` job is gated on `github.event.schedule == '0 6 * * 6'`, but that cron string isn't in the workflow's `on.schedule` list (which only has the five scrape times). GitHub Actions only emits a `schedule` event for crons actually listed, so this condition is only ever satisfied by a manual `workflow_dispatch` — the "weekly" expiry check isn't actually running weekly. Needs either the cron added to `on.schedule` or the `if` condition changed to whichever slot it's meant to piggyback on.
+- **`Tasks/embeddings.py`'s completion notification silently fails.** `run_embedding_pass()` calls `notify_discord(message=..., file_path="embedded_jobs.txt")`, but nothing in the module ever writes `embedded_jobs.txt`. `notify_discord()` tries to `open()` that path, gets a `FileNotFoundError`, and swallows it into a logged error — so the Discord summary for this pass never actually sends, silently.
+- **`JobEnricher._run_scrape()` doesn't distinguish a blocked scrape from structured data.** `Pirate.scrape_apply_url()` can now return `{"blocked": True, "status_code": 403|429}` as well as the schema.org JobPosting dict — but `_run_scrape()` branches on `isinstance(scraped, dict)` for both and treats a blocked response as an (empty) structured payload. It's a harmless no-op today since the blocked dict has none of the expected keys, but it means a 403/429 currently looks identical to "nothing found" in `meta["stages_run"]`, with no distinct signal. `Tasks/expired.py`'s `_deep_check()` already handles this correctly (checks `scraped.get("blocked")` explicitly, counts it in `metrics["blocked"]`, and returns `None` without treating it as expired) — `extractor.py` could mirror that.
+- **Possible upsert conflict-target mismatch.** `azalea.py`/`refine.py` upsert with `conflict_column=["company", "location", "title", "apply_url"]` but the documented schema's `UNIQUE` constraint on `job_list` is only `(title, company, apply_url)`. If the live DB really only has the 3-column constraint, these upserts should be failing outright — worth confirming what's actually deployed. See [[Database-Layer]].
+
+## Recently implemented (previously "planned")
+
+- **pgvector + `nomic-embed-text` RAG pipeline is live**, not just planned. `job_list.embedding` and the new `enrichment_examples` table are written by the new standalone `Tasks/embeddings.py` (`run_embedding_pass()`), decoupled from `enrich_unenriched_jobs()` so a slow first Ollama embedding load never blocks scrape/enrich throughput. It reuses the enrichment's own embedding when deciding whether to promote a job into the example bank, rather than re-embedding. **Not yet wired into any CI schedule** — still needs a cron job in `Automations.yaml` (or its own workflow) to run unattended.
+- **Weekly expiry re-validation is implemented** (`Tasks/expired.py::ExpiryChecker`) — a three-tier escalation (cheap HTTP HEAD/GET → Playwright scrape → LLM `check_expired()`) over all `status='active'` jobs, flipping newly-dead ones to `status='expired'` in one bulk `UPDATE`. See the bug above about its schedule not actually firing weekly yet.
 
 ## Database
 
-- `enrich_attempts` column is referenced in `refine.py`'s retry-cap logic but isn't in a tracked SQL migration anywhere in the repo — if a fresh DB is set up from the `CREATE TABLE` statement in the README, this column needs to be added manually. Worth starting a `migrations/` folder or at least a running changelog of manual `ALTER TABLE` statements applied to the live DB, since this is the second undocumented schema drift found.
+- `enrich_attempts`, `status`, `summary`, `embedding`, and the `enrichment_examples` table are all referenced in code but not in any tracked SQL migration — same undocumented-drift pattern as before, now larger. Worth actually starting a `migrations/` folder rather than continuing to patch live.
 
 ## Enrichment
 
-- Enrichment is invoked separately from scraping (`Tasks/enrich.py`, once/day via CI) rather than inline in `Azalea.run()` — intentional decoupling to bound Ollama enrichment time and avoid coupling scrape failures to enrichment failures.
+- Enrichment is invoked separately from scraping (`Tasks/enrich.py`, once/day via CI) — intentional decoupling to bound Ollama enrichment time and avoid coupling scrape failures to enrichment failures.
 - Groq (`GroqProvider` in `llm.py`) is fully commented out in favor of local Ollama (`deepseek-r1:8b`) — kept in the file as a documented, easy swap-back rather than deleted.
-- pgvector + `nomic-embed-text` (via Ollama) still planned for RAG-style search over job descriptions — not yet in the schema or code.
+- `job.description` is now filled directly from the scraped, trimmed page text rather than LLM-generated — the LLM's job shifted to producing a separate `summary` field plus a `description_looks_valid` sanity signal. Worth watching whether `description` quality/consistency regresses now that it's raw-trimmed text rather than model-normalized prose.
 
 ## Sources
 
-- `RemoteOKHelper.fetch_jobs()` doesn't filter by `position_type` — RemoteOK's API has no such filter, so everything gets pulled and would need post-filtering by tags. Flagged as a `TODO` in `remote.py`.
+- **`RemoteOK` is not implemented at all**, not just gated behind a toggle bug. There is no `JobSource/remote.py` file, no `RemoteOKHelper` class anywhere in the codebase, and `Azalea._init_helpers()` has no branch that would ever register one — `JobSource.REMOTEOK` is a live enum value that every `"REMOTEOK in self.helpers"` check in `Azalea` evaluates as `False`. If RemoteOK is still wanted as a source, it needs to be built from scratch, not just re-enabled.
 
 ## API
 
 - No pagination (`limit` only, no offset/cursor) — will matter once `job_list` grows past a few thousand rows.
 - No auth on any route — fine for a read-only public API, worth revisiting if write endpoints are ever added.
 - `/search` doesn't support a `limit` param.
+- `/jobs` and `/company` order `created_at ASC`; `/sponsor` orders `DESC` — inconsistent, worth checking which is intended.
+- `/sponsor` is currently dead — no part of the enrichment tags schema sets a `sponsorship` key.
 
 ## Repo hygiene
 
-- `debug_page.html` (152K) and `logs/enrich.log` appear to be committed debug artifacts rather than intentional repo content. `Config.DEBUG_SCRAPE` in `Pirate.scrape_apply_url` writes to `debug_page.html` when enabled — worth adding both to `.gitignore` so future debug runs don't get committed by accident.
-- `docs/diagrams/*.md` had drifted stale relative to the `JobEnricher`/`Pirate`/`JobDataSanitizer` refactor — now regenerated (see [[Diagrams]]), but worth treating diagram regeneration as part of the PR checklist for any change touching `Refine/` or `Service/Scrapper.py` going forward, rather than a follow-up cleanup task.
-
-## Known naming quirk (resolved)
-
-`.github/workflows/scarpe.yaml` (typo for "scrape") has since been renamed to `scrape.yaml`.
+- Diagram/wiki regeneration (this pass) covered every module touched since the last sync (`Refine/`, `Service/Scrapper.py`, `Service/db.py`, `Tasks/expired.py`, the new `Tasks/embeddings.py`) plus a few pre-existing inaccuracies found along the way (RemoteOK, `/jobs` sort order, upsert conflict columns). Worth treating diagram/wiki regeneration as part of the PR checklist for any change touching `Refine/`, `Service/`, or `Tasks/` going forward, rather than a periodic catch-up pass like this one.


### PR DESCRIPTION


## What does this PR change?
Updated wiki and fixed minor issues

## Checklist

### If you touched `Refine/`, `Service/Scrapper.py`, or `Utils/sanitate.py`
- [x] Regenerated the matching `docs/diagrams/*_class.md` and `*_seq.md` for any changed class/function — don't leave them describing the old shape (this has happened twice: once when `extractor.py` became `JobEnricher`, once when `azalea.py`'s `list_jobs`/`fin_jobs` changed)
- [x] If a class holds mutable state built in `__init__` (like `JobEnricher.meta`), confirm callers create a fresh instance per unit of work, not one shared instance reused across a loop
- [x] If you added/changed a field the LLM can return, updated `LLMConstants._LLM_PROMPT` **and** the matching sanitizer method in `Utils/sanitate.py`

### If you touched `Service/azalea.py` or anything in the scrape → DB path
- [x] Confirmed `Job.to_dict()` (JSON backup shape) and `Job.to_dict_for_db()` (Postgres shape) aren't mixed up — anything reaching `bulk_upsert`/`upsert` should go through `to_dict_for_db()`
- [x] If you added a new mode/branch (like `test=True`), confirmed it converges on the same DB-insert step as the normal path, rather than duplicating (and potentially diverging from) it

### If you changed the DB schema (new column, changed type, etc.)
- [x] Added the `ALTER TABLE`/`CREATE TABLE` change to `wiki/Database-Layer.md` and the README's schema block — this repo has no `migrations/` folder, so these two places are the only record of what a fresh DB needs (this bit us with `enrich_attempts`)

### If you changed anything covered by the wiki
- [x] Updated the actual page under `wiki/` (not just the diagrams) — `Home.md` specifically is easy to forget since it doesn't get touched by most module-level changes, but it's the landing page
- [x] Searched the changed wiki pages for now-wrong terminology (e.g. a provider/library swap leaving stale references to the old one)

### Before merging
- [x] Ran the actual code path this PR touches, not just read it — an import succeeding isn't the same as the logic being correct (e.g. the `azalea.py` test-mode bug didn't crash, it just silently inserted the wrong data shape)
- [x] If you added a Mermaid diagram or edited one, validated the syntax actually parses (GitHub's renderer will silently show a parse error otherwise) — Mermaid sequence diagrams don't support `try`/`catch`; use `alt`/`else` instead