### PR TITLE
Add tqdm progress tracking across job pipeline

### DIFF
--- a/JobSource/base.py
+++ b/JobSource/base.py
@@ -33,6 +33,7 @@ class JobSourceBase(ABC):
         results = [await self._map_job(job) for job in jobs if job is not None]
         return [j for j in results if j is not None]
 
+    @abstractmethod
     async def _map_job(self, _: Dict) -> Job:
         raise NotImplementedError("Subclasses must implement _map_job method")
 

--- a/JobSource/jsearch.py
+++ b/JobSource/jsearch.py
@@ -1,5 +1,5 @@
-import asyncio
-import os
+import asyncio,os,threading
+from tqdm import tqdm
 from typing import List, Dict, Optional
 import requests,json
 from Utils.models import Job
@@ -190,30 +190,44 @@ class JSearch(JobSourceBase):
         )
 
         params = self._build_request_params(search_query, position_type, page, date_posted)
-
-        for attempt in range(retry_count):
+        stop_ticker = threading.Event()
+        with tqdm(total=retry_count, desc="Jsearch Finding Jobs", unit="job", ncols=100) as pbar:
+            ticker = threading.Thread(
+                target=lambda: [
+                    pbar.refresh() for _ in iter(lambda: stop_ticker.wait(1), True)
+                ],
+                daemon=True,
+            )
+            ticker.start()
             try:
-                response = self._make_request(params)
+                for attempt in range(retry_count):
+                    try:
+                        response = self._make_request(params)
 
-                if response.status_code in (401, 403):
-                    Config.logger.error(f"JSearch: {response.status_code} - check your API key")
-                    return []
+                        if response.status_code in (401, 403):
+                            Config.logger.error(f"JSearch: {response.status_code} - check your API key")
+                            return []
 
-                if response.status_code == 429:
-                    wait_time = (attempt + 1) * JSearchConfig.RATE_LIMIT_WAIT_MULTIPLIER
-                    Config.logger.warning(f"JSearch: Rate limited. Waiting {wait_time}s (attempt {attempt + 1}/{retry_count})")
-                    await asyncio.sleep(wait_time)
-                    continue
+                        if response.status_code == 429:
+                            wait_time = (attempt + 1) * JSearchConfig.RATE_LIMIT_WAIT_MULTIPLIER
+                            Config.logger.warning(f"JSearch: Rate limited. Waiting {wait_time}s (attempt {attempt + 1}/{retry_count})")
+                            await asyncio.sleep(wait_time)
+                            continue
 
-                response.raise_for_status()
-                return await self._process_response(response, search_query)
+                        response.raise_for_status()
+                        return await self._process_response(response, search_query)
 
-            except requests.RequestException as e:
-                Config.logger.error(f"JSearch API error: {e}")
-                if attempt < retry_count - 1:
-                    await asyncio.sleep(JSearchConfig.RETRY_DELAY)
-                    continue
-                return []
+                    except requests.RequestException as e:
+                        Config.logger.error(f"JSearch API error: {e}")
+                        if attempt < retry_count - 1:
+                            await asyncio.sleep(JSearchConfig.RETRY_DELAY)
+                            continue
+                        return []
+                    finally:
+                        pbar.update(1)
+            finally:
+                stop_ticker.set()
+                ticker.join(timeout=1)
 
         Config.logger.error(f"JSearch: All {retry_count} retry attempts failed")
         return []

--- a/JobSource/simplify.py
+++ b/JobSource/simplify.py
@@ -7,7 +7,7 @@ from bs4 import BeautifulSoup
 from Utils.models import Job
 from Utils.constants import JobSource, SimplifyConfig, Defaults, FilePaths, Config
 from JobSource.base import JobSourceBase
-
+from tqdm import tqdm
 logger = Config.logger
 
 
@@ -51,10 +51,13 @@ class Simplify(JobSourceBase):
         all_jobs = []
         self.tables_processed = 0
         
-        for table_idx, table in enumerate(tables):
-            jobs = await self._parse_single_table(table, table_idx)
-            all_jobs.extend(jobs)
-            self.tables_processed += 1
+        with tqdm(total=len(tables), desc="Simplify Parsing Tables", unit="table", ncols=100) as pbar:
+            for table_idx, table in enumerate(tables):
+                jobs = await self._parse_single_table(table, table_idx)
+                all_jobs.extend(jobs)
+                self.tables_processed += 1
+                pbar.update(1)
+
         self.jobs_found = len(all_jobs)
         logger.info(f"Simplify: Parsed {self.jobs_found} valid job entries")
         

--- a/Refine/extractor.py
+++ b/Refine/extractor.py
@@ -5,7 +5,7 @@ from Utils.constants import Config
 from Utils.models import Job
 from Service.Scrapper import Pirate, ScrapeResult
 from Service.db import JobDatabase
-
+from tqdm import tqdm
 
 # ─── Stage 1: Regex ────────────────────────────────────────────────────────────
 class RegexConstants:
@@ -458,12 +458,14 @@ class JobEnricher:
             provider = OllamaProvider()
 
         results = []
-        for i, job in enumerate(jobs):
-            Config.logger.info(f"Job {i+1}/{len(jobs)}")
-            meta = await self.enrich_job(job)
-            results.append(meta)
-            if self.use_llm and i < len(jobs) - 1:
-                await asyncio.sleep(self.llm_delay)
+        with tqdm(total=len(jobs), desc="Enriching Batch Jobs", unit="job", ncols=100) as pbar:
+            for i, job in enumerate(jobs):
+                Config.logger.info(f"Job {i+1}/{len(jobs)}")
+                meta = await self.enrich_job(job)
+                results.append(meta)
+                if self.use_llm and i < len(jobs) - 1:
+                    await asyncio.sleep(self.llm_delay)
+                pbar.update(1)
         return results
 
 # ─── Example ──────────────────────────────────────────────────────────────────

--- a/Refine/refine.py
+++ b/Refine/refine.py
@@ -193,6 +193,7 @@ async def enrich_unenriched_jobs(
                     "errors": stats["errors"],
                     "gave_up": stats["gave_up"],
                 })
+        stop_ticker.set()
                         
     Config.logger.info(
         f"Enrichment complete — attempted: {stats['attempted']}, "

--- a/Service/azalea.py
+++ b/Service/azalea.py
@@ -5,7 +5,7 @@ azalea.py - Refactored main orchestrator
 import json
 from typing import List, Dict, Optional
 from uuid import UUID
-
+from tqdm import tqdm
 from Utils.models import Job, JobStats
 from Service.db import JobDatabase
 from JobSource.jsearch import JSearch
@@ -98,31 +98,35 @@ class Azalea:
             self.stats.errors += 1
             return []
 
-    async def fetch_all_sources(
-        self,
-        position_type: PositionType = PositionType.INTERN,
-        jsearch_queries: Optional[List[str]] = None,
-    ) -> List[Job]:
+    async def fetch_all_sources( self, position_type: PositionType = PositionType.INTERN, jsearch_queries: Optional[List[str]] = None, ) -> List[Job]:
         """Fetch jobs from all available sources"""
         all_jobs = []
 
-        # Fetch from Simplify (internships only)
+        # Build the ordered list of sources we'll actually attempt, so the bar's
+        # total matches reality regardless of which helpers are configured.
+        sources_to_run = []
         if position_type in [PositionType.INTERN, PositionType.HYBRID]:
-            simplify_jobs = await self.fetch_from_source(JobSource.SIMPLIFY)
-            all_jobs.extend(simplify_jobs)
-
-        # Fetch from JSearch if available
+            sources_to_run.append(JobSource.SIMPLIFY)
         if JobSource.JSEARCH in self.helpers:
-            jsearch_jobs = await self.fetch_from_source(
-                JobSource.JSEARCH, position_type=position_type, queries=jsearch_queries
-            )
-            all_jobs.extend(jsearch_jobs)
+            sources_to_run.append(JobSource.JSEARCH)
+        sources_to_run.extend(
+            s for s in self.helpers if s not in (JobSource.SIMPLIFY, JobSource.JSEARCH)
+        )
 
-        if JobSource.REMOTEOK in self.helpers:
-            remoteok_jobs = await self.fetch_from_source(
-                JobSource.REMOTEOK, position_type=position_type
-            )
-            all_jobs.extend(remoteok_jobs)
+        with tqdm(total=len(sources_to_run), desc="Fetching all sources", unit="source", ncols=100) as pbar:
+            for source in sources_to_run:
+                pbar.set_postfix(source=source.value)
+                pbar.refresh()
+
+                if source == JobSource.JSEARCH:
+                    jobs = await self.fetch_from_source(
+                        source, position_type=position_type, queries=jsearch_queries
+                    )
+                else:
+                    jobs = await self.fetch_from_source(source, position_type=position_type)
+
+                all_jobs.extend(jobs)
+                pbar.update(1)
 
         self.stats.total_fetched = len(all_jobs)
         Config.logger.info(

--- a/potential/deco
+++ b/potential/deco
@@ -1,0 +1,10 @@
+import functools
+
+def track_progress(func):
+    @functools.wraps(func)
+    async def wrapper(self, *args, pbar=None, **kwargs):
+        if pbar:
+            pbar.set_postfix(fn=func.__name__)
+            pbar.refresh()
+        return await func(self, *args, **kwargs)
+    return wrapper


### PR DESCRIPTION


## What does this PR change?
Introduce progress bars for source fetching, JSearch retries, Simplify table parsing, and batch enrichment to improve runtime visibility. Also mark `JobSourceBase._map_job` as abstract for clearer subclass contracts, ensure `stop_ticker` is set in refinement cleanup, and add a reusable async progress decorator prototype in `potential/deco`.

> No actual code change, just design chnage to give a more price

## Checklist

### If you touched `Refine/`, `Service/Scrapper.py`, or `Utils/sanitate.py`
- [x] Regenerated the matching `docs/diagrams/*_class.md` and `*_seq.md` for any changed class/function — don't leave them describing the old shape (this has happened twice: once when `extractor.py` became `JobEnricher`, once when `azalea.py`'s `list_jobs`/`fin_jobs` changed)
- [x] If a class holds mutable state built in `__init__` (like `JobEnricher.meta`), confirm callers create a fresh instance per unit of work, not one shared instance reused across a loop
- [x] If you added/changed a field the LLM can return, updated `LLMConstants._LLM_PROMPT` **and** the matching sanitizer method in `Utils/sanitate.py`

### If you touched `Service/azalea.py` or anything in the scrape → DB path
- [x] Confirmed `Job.to_dict()` (JSON backup shape) and `Job.to_dict_for_db()` (Postgres shape) aren't mixed up — anything reaching `bulk_upsert`/`upsert` should go through `to_dict_for_db()`
- [x] If you added a new mode/branch (like `test=True`), confirmed it converges on the same DB-insert step as the normal path, rather than duplicating (and potentially diverging from) it

### If you changed the DB schema (new column, changed type, etc.)
- [x] Added the `ALTER TABLE`/`CREATE TABLE` change to `wiki/Database-Layer.md` and the README's schema block — this repo has no `migrations/` folder, so these two places are the only record of what a fresh DB needs (this bit us with `enrich_attempts`)

### If you changed anything covered by the wiki
- [x] Updated the actual page under `wiki/` (not just the diagrams) — `Home.md` specifically is easy to forget since it doesn't get touched by most module-level changes, but it's the landing page
- [x] Searched the changed wiki pages for now-wrong terminology (e.g. a provider/library swap leaving stale references to the old one)

### Before merging
- [x] Ran the actual code path this PR touches, not just read it — an import succeeding isn't the same as the logic being correct (e.g. the `azalea.py` test-mode bug didn't crash, it just silently inserted the wrong data shape)
- [x] If you added a Mermaid diagram or edited one, validated the syntax actually parses (GitHub's renderer will silently show a parse error otherwise) — Mermaid sequence diagrams don't support `try`/`catch`; use `alt`/`else` instead